### PR TITLE
feat(logs): merge logs together by timestamp

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -3,11 +3,14 @@ package cmd
 import (
 		"fmt"
 		"strings"
+	  "time"
+		"sort"
 		"encoding/json"
 		"github.com/spf13/cobra"
 )
 
 var Time bool
+var Separate bool
 // logsCmd represents the logs command
 var logsCmd = &cobra.Command{
 		Use:   "logs",
@@ -17,7 +20,8 @@ var logsCmd = &cobra.Command{
 }
 
 func init() {
-	  RootCmd.PersistentFlags().BoolVarP(&Time, "time", "t", false, "append time to logs")
+	  logsCmd.PersistentFlags().BoolVarP(&Time, "time", "t", false, "append time to logs")
+		logsCmd.PersistentFlags().BoolVarP(&Separate, "separate", "s", false, "print logs by each container")
 		RootCmd.AddCommand(logsCmd)
 }
 
@@ -37,22 +41,111 @@ func logs(cmd *cobra.Command, args []string) {
 			if err != nil {
 			    fmt.Println(err)
 			}
-			for _, provider := range helmitObject.Replicas {
-					for _, container := range provider.Containers {
-						  fmt.Printf("--- Name: %s\n", container.Name)
-							fmt.Printf("--- Id: %s\n", container.Id)
-							fmt.Printf("--- Image %s\n", container.Image)
-							for _, log := range container.Logs {
-								  line := strings.Split(log, ",")
-									line = strings.Split(line[0], " ")
 
-									if Time == false {
-									  line = append(line[:0], line[1:]...)
-									}
-
-                  fmt.Println(strings.Join(line, " "))
-							}
-					}
+			if Separate == true {
+			    printSeparateLogs(helmitObject)
+			} else {
+          printMergedLogs(helmitObject)
 			}
 		}
+}
+
+// Object that contains a containers logs
+type LogsObject struct {
+	Name string
+	Id string
+	Image string
+	Logs Logs
+}
+
+type LogObject struct {
+	Time time.Time
+	Log string
+}
+
+type Logs []LogObject
+
+func (slice Logs) Len() int {
+	return len(slice)
+}
+
+func (slice Logs) Less(i, j int) bool {
+	return slice[i].Time.Before(slice[j].Time)
+}
+
+func (slice Logs) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+func printMergedLogs(shipment HelmitResponse) {
+	layout := "2006-01-02T15:04:05.999999999Z"
+	shipmentLogs := make([]LogsObject, len(shipment.Replicas))
+	for _, provider := range shipment.Replicas {
+			for _, container := range provider.Containers {
+				  var containerLogs = Logs{}
+					for _, log := range container.Logs {
+							line := strings.Fields(log)
+							timeValue, err := time.Parse(layout, line[0])
+							if err != nil {
+									timeValue, err = time.Parse(layout, line[0][:1])
+									if err != nil {
+											continue
+									}
+							}
+
+							var logObject = LogObject{}
+
+							logObject.Time = timeValue
+							logObject.Log = strings.Join(line, " ")
+
+							containerLogs = append(containerLogs, logObject)
+					}
+					var logsObject  = LogsObject{}
+					logsObject.Name = container.Name
+					logsObject.Id = container.Id
+					logsObject.Image = container.Image
+					logsObject.Logs = containerLogs
+					shipmentLogs = append(shipmentLogs, logsObject)
+			}
+	}
+
+	var mergedLogs Logs
+	for _, logObject := range shipmentLogs {
+		for _, logObj := range logObject.Logs {
+			  newLog := logObject.Name + ":" + logObject.Id[0:5] + "  | "
+				if Time == true {
+				     newLog = newLog + logObj.Time.String()  + ", "
+				}
+
+				logObj.Log = newLog + logObj.Log + "\n"
+			  mergedLogs = append(mergedLogs, logObj)
+		}
+	}
+
+	sort.Sort(mergedLogs)
+
+	for _, log := range mergedLogs {
+			fmt.Printf(log.Log)
+	}
+}
+
+// printShipmentLogs
+// prints the logs separatly for each shipment
+func printSeparateLogs(shipment HelmitResponse) {
+	for _, provider := range shipment.Replicas {
+			for _, container := range provider.Containers {
+					fmt.Printf("--- Name: %s\n", container.Name)
+					fmt.Printf("--- Id: %s\n", container.Id)
+					fmt.Printf("--- Image %s\n", container.Image)
+					for _, log := range container.Logs {
+							line := strings.Fields(log)
+
+							if Time == false {
+								line = append(line[:0], line[1:]...)
+							}
+
+							fmt.Println(strings.Join(line, " "))
+					}
+			}
+	}
 }


### PR DESCRIPTION
- merging logs together by default, just like docker-compose
- printing name:containerID[0:5] before container log
- made separate logs an optional feature with -s
