### PR TITLE
feat(logs): add tail flag

### DIFF
--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -183,6 +184,18 @@ func GetLogs(barge string, shipment string, env string) string {
 	}
 
 	return body
+}
+
+// GetLogStreamer return reader object to parse docker container logs
+func GetLogStreamer(streamer string) (reader *bufio.Reader, err error) {
+	resp, err := http.Get(streamer)
+
+	if err != nil {
+		return
+	}
+
+	reader = bufio.NewReader(resp.Body)
+	return
 }
 
 // GetShipmentStatus returns the running status of a shipment


### PR DESCRIPTION
## BREAKING CHANGE
- changed -t for time to be -T so -t can be for tail. I tried to do -f, but it's already taken globally by --file.
## Features
- ads the ability to tail logs
- works with all previous options
## Todos (can be merged without these features)
- if stream is broken, request from helmit for new containers, because the container we were listening too most likely died. This will cause the stream to break. However all the user has to do is rerun the command and all will be well again, as helmit, will find the new containers.
- I believe there is potentially a way to achieve this functionality without adding any code to harbor-compose. We could put this combined streaming logic into helmit, so that any UI can benefit from the ability to stream logs from all containers at once. 
