### PR TITLE
implemented deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You can also manage multiple shipments using Harbor Compose by listing them in y
 
 ### CI/CD
 
-The `deploy` command can be used to trigger a deployment of a new version of a Dqocker image.  This works from public build services (e.g.; Circle CI, Travis CI, etc.) by using the shipment build token specified using either the `BUILD_TOKEN` environment variable or the --token flag.
+The `deploy` command can be used to trigger a deployment of a new version of a Docker image.  This works from public build services (e.g.; Circle CI, Travis CI, etc.) by using the shipment build token specified using either the `BUILD_TOKEN` environment variable or the --token flag.
 
 
 #### Authentication

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Using Harbor Compose is basically a four-step process.
 Just like `docker-compose`, `harbor-compose` has similar commands for managing the lifecycle of your app on Harbor:
 
 - Start and stop services
+- Upload environment variables and scale replicas
 - View the status of running services
 - Stream the log output of running services
+- Trigger an image deployment from a public build system (like Circle CI, Travis CI, etc.)
 
 
 A simple `docker-compose.yml` might look like this:
@@ -98,10 +100,10 @@ $ sudo wget -O /usr/local/bin/harbor-compose https://github.com/turnerlabs/harbo
 $ docker run -it --rm -v `pwd`:/work quay.io/turner/harbor-compose up
 ```
 
-- or if you want to reuse your session (and use a specific version):
+- or if you want to reuse your session:
 
 ```
-$ docker run -it —rm -v `pwd`:/work -v ${HOME}/.harbor:/root/.harbor quay.io/turner/harbor-compose:0.8.2 up
+$ docker run -it —rm -v `pwd`:/work -v ${HOME}/.harbor:/root/.harbor quay.io/turner/harbor-compose up
 ```
 
 
@@ -123,6 +125,12 @@ Run your shipment locally in Docker (practically identically to how it runs in H
 
 ```
 $ docker-compose up
+```
+
+Push your images to a registry.
+
+```
+$ docker-compose push
 ```
 
 Scale your shipment by changing the replicas in `harbor-compose.yml`, or change your environment variables and re-deploy, or deploy a new image, etc....
@@ -157,6 +165,12 @@ $ harbor-compose down --delete
 ```
 
 You can also manage multiple shipments using Harbor Compose by listing them in your harbor-compose.yml file.  This is particularly useful if you have a web/worker, or microservices type application where each shipment can be scaled independently.
+
+
+### CI/CD
+
+The `deploy` command can be used to trigger a deployment of a new version of a Dqocker image.  This works from public build services (e.g.; Circle CI, Travis CI, etc.) by using the shipment build token specified using either the `BUILD_TOKEN` environment variable or the --token flag.
+
 
 #### Authentication
 

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -11,7 +11,7 @@ import (
 // catalogCmd represents the up command
 var catalogCmd = &cobra.Command{
 	Use:   "catalog",
-	Short: "Add containers in docker-compose to Harbor Catalog",
+	Short: "Add containers defined in a docker compose file to the harbor catalog",
 	Run:   catalog,
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -95,8 +95,7 @@ func deploy(cmd *cobra.Command, args []string) {
 				Catalog: catalog,
 			}
 
-			Deploy(shipmentName, shipment.Env, shipmentBuildToken, deployRequest)
-
+			Deploy(shipmentName, shipment.Env, shipmentBuildToken, deployRequest, "ec2")
 		}
 
 		fmt.Println("done")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/docker/libcompose/docker"
+	"github.com/docker/libcompose/docker/ctx"
+	"github.com/docker/libcompose/project"
+	"github.com/spf13/cobra"
+)
+
+// deployCmd represents the up command
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Trigger an image deployment for all shipments and containers defined in compose files",
+	Long:  "Note that the deploy command is a subset of the up command without updates for environment variables, replicas, barge info, etc.",
+	Run:   deploy,
+}
+
+var shipmentBuildToken string
+
+func init() {
+	deployCmd.PersistentFlags().StringVarP(&shipmentBuildToken, "token", "t", "", "the shipment build token to use")
+	RootCmd.AddCommand(deployCmd)
+}
+
+//deploy iterates shipments and containers and uses the Customs API to trigger deployments.
+func deploy(cmd *cobra.Command, args []string) {
+
+	//obtain build token
+	buildTokenEnvVar := os.Getenv("BUILD_TOKEN")
+
+	//cli flag overrides env var
+	if len(shipmentBuildToken) == 0 {
+		shipmentBuildToken = buildTokenEnvVar
+	}
+
+	//validate build token
+	if len(shipmentBuildToken) == 0 {
+		log.Fatal("A shipment build token is required. Please specify an environment variable named, \"BUILD_TOKEN\" or the --token flag.")
+	}
+
+	//read the harbor compose file
+	harborCompose := DeserializeHarborCompose(HarborComposeFile)
+
+	//use libcompose to parse compose yml file
+	dockerComposeProject, err := docker.NewProject(&ctx.Context{
+		Context: project.Context{
+			ComposeFiles: []string{DockerComposeFile},
+		},
+	}, nil)
+
+	if err != nil {
+		log.Fatal("error parsing compose file" + err.Error())
+	}
+
+	//validate the compose file
+	_, err = dockerComposeProject.Config()
+	if err != nil {
+		log.Fatal("error parsing compose file" + err.Error())
+	}
+
+	//iterate shipments
+	for shipmentName, shipment := range harborCompose.Shipments {
+		fmt.Printf("deploying images for Shipment: %v %v ...\n", shipmentName, shipment.Env)
+
+		// loop over containers in docker-compose file
+		for _, containerName := range shipment.Containers {
+
+			//lookup the container in the list of services in the docker-compose file
+			serviceConfig, found := dockerComposeProject.GetServiceConfig(containerName)
+			if !found {
+				log.Fatal("could not find service in docker compose file")
+			}
+
+			//parse image:tag and map to name/version
+			parsedImage := strings.Split(serviceConfig.Image, ":")
+			tag := parsedImage[1]
+
+			//lookup container image in the catalog and catalog if missing
+			catalog := !IsContainerVersionCataloged(containerName, tag)
+
+			//now deploy container
+			if Verbose {
+				log.Printf("deploying container: %v\n", containerName)
+			}
+
+			deployRequest := DeployRequest{
+				Name:    containerName,
+				Image:   serviceConfig.Image,
+				Version: tag,
+				Catalog: catalog,
+			}
+
+			Deploy(shipmentName, shipment.Env, shipmentBuildToken, deployRequest)
+
+		}
+
+		fmt.Println("done")
+
+	} //shipments
+}

--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -471,13 +471,14 @@ func IsContainerVersionCataloged(name string, version string) bool {
 }
 
 // Deploy deploys (and catalogs) a shipment container to an environment
-func Deploy(shipment string, env string, buildToken string, deployRequest DeployRequest) {
+func Deploy(shipment string, env string, buildToken string, deployRequest DeployRequest, provider string) {
 
 	//build URI
 	values := make(map[string]interface{})
 	values["shipment"] = shipment
 	values["env"] = env
-	template, _ := uritemplates.Parse(customsURI + "/deploy/{shipment}/{env}/ec2")
+	values["provider"] = provider
+	template, _ := uritemplates.Parse(customsURI + "/deploy/{shipment}/{env}/{provider}")
 	uri, _ := template.Expand(values)
 	request := gorequest.New().Get(uri)
 

--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -18,6 +18,7 @@ var authAPI = "http://auth.services.dmtio.net"
 var helmitURI = "http://helmit.services.dmtio.net"
 var harborURI = "http://harbor.services.dmtio.net"
 var catalogitURI = "http://catalogit.services.dmtio.net"
+var customsURI = "https://customs.services.dmtio.net"
 
 // GetShipmentEnvironment returns a harbor shipment from the API
 func GetShipmentEnvironment(username string, token string, shipment string, env string) *ShipmentEnvironment {
@@ -434,4 +435,76 @@ func Catalogit(container CatalogitContainer) (response string, err []error) {
 	}
 
 	return "Successfully Cataloged Container " + container.Name, nil
+}
+
+//IsContainerVersionCataloged determines whether or not a container/version exists in the catalog
+func IsContainerVersionCataloged(name string, version string) bool {
+
+	//build URI
+	values := make(map[string]interface{})
+	values["name"] = name
+	values["version"] = version
+	template, _ := uritemplates.Parse(customsURI + "/catalog/{name}/{version}/")
+	uri, _ := template.Expand(values)
+	if Verbose {
+		log.Println("fetching: " + uri)
+	}
+
+	//issue request
+	res, _, err := gorequest.New().Get(uri).EndBytes()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//not found
+	if res.StatusCode == 404 {
+		return false
+	}
+
+	//throw error if not 200
+	if res.StatusCode != 200 {
+		log.Fatalf("GET %v returned %v", uri, res.StatusCode)
+	}
+
+	return true
+}
+
+// Deploy deploys (and catalogs) a shipment container to an environment
+func Deploy(shipment string, env string, buildToken string, deployRequest DeployRequest) {
+
+	//build URI
+	values := make(map[string]interface{})
+	values["shipment"] = shipment
+	values["env"] = env
+	template, _ := uritemplates.Parse(customsURI + "/deploy/{shipment}/{env}/ec2")
+	uri, _ := template.Expand(values)
+	request := gorequest.New().Get(uri)
+
+	if Verbose {
+		log.Printf("POST " + uri)
+	}
+
+	//make network request
+	res, body, err := request.
+		Post(uri).
+		Set("x-build-token", buildToken).
+		Send(deployRequest).
+		EndBytes()
+
+	//handle errors
+	if err != nil {
+		log.Println("an error occurred calling customs api")
+		log.Fatal(err)
+	}
+
+	//logging
+	if Verbose || res.StatusCode != 200 {
+		log.Printf("customs api returned a %v", res.StatusCode)
+		log.Println(string(body))
+	}
+
+	if res.StatusCode != 200 {
+		log.Fatal("customs/deploy failed")
+	}
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -171,3 +171,11 @@ type CatalogitContainer struct {
 	Image   string `json:"image"`
 	Version string `json:"version"`
 }
+
+// DeployRequest represents a request to deploy a shipment/container to an environment
+type DeployRequest struct {
+	Name    string `json:"name"`
+	Image   string `json:"image"`
+	Version string `json:"version"`
+	Catalog bool   `json:"catalog"`
+}


### PR DESCRIPTION
This PR implements the `deploy` command which deploys all containers in all shipments defined by compose files.  This command is a subset of the `up` command without support for uploading environment variables or making any other shipment modifications.  It's useful for making CI/CD pipelines even easier for teams that are already using compose files and Harbor Compose.


### usage
```
MY_APP_DEV_TOKEN=xyz harbor-compose deploy
```

There's a usage example [here](https://github.com/turnerlabs/harbor-audit/blob/358bc1dbd2d115da7cbd90771d9c3db932f485c4/circle.yml).  
