### PR TITLE
closes issue #74 - have catalog command use customs api

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,18 @@ And then simply run
 harbor-compose deploy -e qa
 ```
 
-This allows for a clean CI/CD workflow in your build scripts...
+This allows for a clean CI/CD work flow in your build scripts...
 
 ```
 docker-compose build
 docker-compose push
 harbor-compose deploy
+```
+
+If you're just doing CI and not CD, you can use the `catalog` command to catalog all of the built docker images but not deploy them.
+
+```
+docker-compose build
+docker-compose push
+harbor-compose catalog
 ```

--- a/cmd/buildToken.go
+++ b/cmd/buildToken.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+func getBuildTokenEnvVar(shipment string, environment string) string {
+
+	//look for envvar for this shipment/environment that matches naming convention: SHIPMENT_ENV_TOKEN
+	envvar := fmt.Sprintf("%v_%v_TOKEN", strings.Replace(strings.ToUpper(shipment), "-", "_", -1), strings.ToUpper(environment))
+	if Verbose {
+		log.Printf("looking for environment variable named: %v\n", envvar)
+	}
+	buildTokenEnvVar := os.Getenv(envvar)
+
+	//validate build token
+	if len(buildTokenEnvVar) == 0 {
+		log.Fatalf("A shipment/environment build token is required. Please specify an environment variable named, %v", envvar)
+	}
+
+	return buildTokenEnvVar
+}

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -5,14 +5,27 @@ import (
 	"log"
 	"strings"
 
+	"github.com/docker/libcompose/docker"
+	"github.com/docker/libcompose/docker/ctx"
+	"github.com/docker/libcompose/project"
 	"github.com/spf13/cobra"
 )
 
 // catalogCmd represents the up command
 var catalogCmd = &cobra.Command{
 	Use:   "catalog",
-	Short: "Add containers defined in a docker compose file to the harbor catalog",
-	Run:   catalog,
+	Short: "Add container images defined in compose files to the Harbor catalog",
+	Long: `Add container images defined in compose files to the Harbor catalog.
+	
+This command is safe to run multiple times.  In other words, the command will not fail if the specified name/version has already been cataloged.
+
+Also note that a shipment build token is required to be specified as an environment variable using the specific naming convention below.  Shipment build tokens are generated at the environment level so you can use any environment you wish.
+
+Example (shipment = mss-app-web):
+
+MSS_APP_WEB_DEV_TOKEN=xyz harbor-compose catalog
+`,
+	Run: catalog,
 }
 
 func init() {
@@ -24,69 +37,67 @@ func init() {
 // catalog images
 func catalog(cmd *cobra.Command, args []string) {
 
-	// read the harbor compose file
+	//read the harbor compose file
 	harborCompose := DeserializeHarborCompose(HarborComposeFile)
 
-	// read the docker compose file
-	dockerCompose := DeserializeDockerCompose(DockerComposeFile)
+	//use libcompose to parse yml file
+	dockerComposeProject, err := docker.NewProject(&ctx.Context{
+		Context: project.Context{
+			ComposeFiles: []string{DockerComposeFile},
+		},
+	}, nil)
+
+	if err != nil {
+		log.Fatal("error parsing compose file" + err.Error())
+	}
+
+	//validate the compose file
+	_, err = dockerComposeProject.Config()
+	if err != nil {
+		log.Fatal("error parsing compose file" + err.Error())
+	}
 
 	//iterate shipments
 	for shipmentName, shipment := range harborCompose.Shipments {
-		fmt.Printf("Cataloging images for Shipment: %v ...\n", shipmentName)
-
-		if Verbose {
-			log.Printf("cataloging shipment: %v/%v", shipmentName, shipment.Env)
-		}
+		fmt.Printf("cataloging images for shipment: %v ...\n", shipmentName)
 
 		// loop over containers in docker-compose file
-		for containerIndex, containerName := range shipment.Containers {
-
-			if Verbose {
-				log.Printf("processing container: %v %v", containerName, containerIndex)
-			}
+		for _, containerName := range shipment.Containers {
 
 			//lookup the container in the list of services in the docker-compose file
-			container, isset := dockerCompose.Services[containerName]
+			serviceConfig, found := dockerComposeProject.GetServiceConfig(containerName)
+			if !found {
+				log.Fatal("could not find service in docker compose file")
+			}
 
-			if isset == true {
-				// catalog the containers in the shipment
-				CatalogContainer(containerName, container.Image)
+			//parse image:tag
+			parsedImage := strings.Split(serviceConfig.Image, ":")
+			tag := parsedImage[1]
+
+			//lookup container image in the catalog and catalog if missing
+			if !IsContainerVersionCataloged(containerName, tag) {
+
+				if Verbose {
+					log.Printf("cataloging container: %v\n", containerName)
+				}
+
+				catalogContainer := CatalogitContainer{
+					Name:    containerName,
+					Image:   serviceConfig.Image,
+					Version: tag,
+				}
+
+				//get for envvar for this shipment/environment
+				buildTokenEnvVar := getBuildTokenEnvVar(shipmentName, shipment.Env)
+
+				CatalogCustoms(shipmentName, shipment.Env, buildTokenEnvVar, catalogContainer, "ec2")
+
+			} else if Verbose {
+				log.Printf("%s:%s has already been cataloged\n", containerName, tag)
 			}
 		}
 
 		fmt.Println("done")
 
 	} //shipments
-}
-
-// CatalogContainer will create a container object from name and image params
-// Will send POST to catalogit api
-func CatalogContainer(name string, image string) {
-
-	if Verbose {
-		log.Printf("cataloging container %v", name)
-	}
-
-	//parse image:tag and map to name/version
-	parsedImage := strings.Split(image, ":")
-
-	newContainer := CatalogitContainer{
-		Name:    name,
-		Image:   image,
-		Version: parsedImage[1],
-	}
-
-	// send POST to catalogit
-	// if post failes and says image already exists, do not exit 1
-	//trigger shipment
-	message, err := Catalogit(newContainer)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// cataloged successfully
-	if Verbose {
-		fmt.Println(message)
-	}
 }

--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -509,3 +509,43 @@ func Deploy(shipment string, env string, buildToken string, deployRequest Deploy
 		log.Fatal("customs/deploy failed")
 	}
 }
+
+// CatalogCustoms catalogs a container using the customs catalog api
+func CatalogCustoms(shipment string, env string, buildToken string, catalogRequest CatalogitContainer, provider string) {
+
+	//POST /catalog/:shipment/:environment/:provider
+	values := make(map[string]interface{})
+	values["shipment"] = shipment
+	values["env"] = env
+	values["provider"] = provider
+	template, _ := uritemplates.Parse(customsURI + "/catalog/{shipment}/{env}/{provider}")
+	uri, _ := template.Expand(values)
+	request := gorequest.New().Get(uri)
+
+	if Verbose {
+		log.Printf("POST " + uri)
+	}
+
+	//make network request
+	res, body, err := request.
+		Post(uri).
+		Set("x-build-token", buildToken).
+		Send(catalogRequest).
+		EndBytes()
+
+	//handle errors
+	if err != nil {
+		log.Println("an error occurred calling customs api")
+		log.Fatal(err)
+	}
+
+	//logging
+	if Verbose || res.StatusCode != 200 {
+		log.Printf("customs api returned a %v", res.StatusCode)
+		log.Println(string(body))
+	}
+
+	if res.StatusCode != 200 {
+		log.Fatal("customs/catalog failed")
+	}
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -141,7 +141,7 @@ func createShipment(username string, token string, shipmentName string, dockerCo
 		}
 
 		// catalog containers
-		CatalogContainer(container, dockerService.Image)
+		catalogContainer(container, dockerService.Image)
 
 		//parse image:tag and map to name/version
 		parsedImage := strings.Split(dockerService.Image, ":")
@@ -260,7 +260,7 @@ func updateShipment(username string, token string, currentShipment *ShipmentEnvi
 		dockerService := dockerCompose.Services[container]
 
 		// catalog containers
-		CatalogContainer(container, dockerService.Image)
+		catalogContainer(container, dockerService.Image)
 
 		//update the shipment/container with the new image
 		if !shipment.IgnoreImageVersion {
@@ -338,5 +338,35 @@ func envVar(name string, value string) EnvVarPayload {
 		Name:  name,
 		Value: value,
 		Type:  "basic",
+	}
+}
+
+func catalogContainer(name string, image string) {
+
+	if Verbose {
+		log.Printf("cataloging container %v", name)
+	}
+
+	//parse image:tag and map to name/version
+	parsedImage := strings.Split(image, ":")
+
+	newContainer := CatalogitContainer{
+		Name:    name,
+		Image:   image,
+		Version: parsedImage[1],
+	}
+
+	// send POST to catalogit
+	// if post failes and says image already exists, do not exit 1
+	//trigger shipment
+	message, err := Catalogit(newContainer)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// cataloged successfully
+	if Verbose {
+		fmt.Println(message)
 	}
 }


### PR DESCRIPTION
Addresses issue [#74](https://github.com/turnerlabs/harbor-compose/issues/74).  The `catalog` command should use the customs api so that it will work with public CI systems.