### PR TITLE
up now checks catalog before cataloging

### DIFF
--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -410,7 +410,7 @@ func DeleteShipmentEnvironment(username string, token string, shipment string, e
 }
 
 // Catalogit sends a POST to the catalogit api
-func Catalogit(container CatalogitContainer) (response string, err []error) {
+func Catalogit(container CatalogitContainer) (string, []error) {
 
 	if Verbose {
 		log.Printf("Sending POST to: %v /v1/containers\n", catalogitURI)
@@ -422,23 +422,12 @@ func Catalogit(container CatalogitContainer) (response string, err []error) {
 		Send(container).
 		EndBytes()
 
-	// handle errors
-	if err != nil && resp.StatusCode != 422 {
-		log.Println("an error occurred calling catalogit api")
-		log.Fatal(err)
+	//treat non-200 as error
+	if resp.StatusCode != 200 {
+		err = append(err, fmt.Errorf("catalogit api returned a %v", resp.StatusCode))
 	}
 
-	if Verbose && resp.StatusCode == 422 {
-		log.Println("container has already been cataloged.")
-	}
-
-	// if verbose or non-200, log status code and message body
-	if Verbose || (resp.StatusCode != 200 && resp.StatusCode != 422) {
-		log.Printf("catalogit api returned a %v", resp.StatusCode)
-		log.Println(string(body))
-	}
-
-	return "Successfully Cataloged Container " + container.Name, nil
+	return string(body), err
 }
 
 //IsContainerVersionCataloged determines whether or not a container/version exists in the catalog

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -350,24 +350,29 @@ func catalogContainer(name string, image string) {
 
 	//parse image:tag and map to name/version
 	parsedImage := strings.Split(image, ":")
+	tag := parsedImage[1]
 
-	newContainer := CatalogitContainer{
-		Name:    name,
-		Image:   image,
-		Version: parsedImage[1],
-	}
+	//lookup container image in the catalog and catalog if missing
+	if !IsContainerVersionCataloged(name, tag) {
 
-	// send POST to catalogit
-	// if post fails and says image already exists, do not exit 1
-	//trigger shipment
-	message, err := Catalogit(newContainer)
+		newContainer := CatalogitContainer{
+			Name:    name,
+			Image:   image,
+			Version: tag,
+		}
 
-	if err != nil {
-		log.Fatal(err)
-	}
+		message, err := Catalogit(newContainer)
 
-	// cataloged successfully
-	if Verbose {
-		fmt.Println(message)
+		if Verbose {
+			fmt.Println(message)
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	} else {
+		if Verbose {
+			log.Printf("container %v already cataloged", name)
+		}
 	}
 }


### PR DESCRIPTION
This is done to avoid having to parse catalogit's changing http response code if a container/tag already exists.

With latest build users are getting the following error/warning.  This PR fixes it:
```
$ hc up
Starting mss-poc-thingproxy ...
2017/05/12 16:45:32 catalogit api returned a 409
2017/05/12 16:45:32 {"error":"Container Error: There is already a combination of mss-poc-thingproxy:0.0.13-rc.33. Specify unique combinations."}
mss-poc-thingproxy.dev.services.ec2.dmtio.net:80
done
```