### PR TITLE
adds buildtoken command (closes #100)

### DIFF
--- a/cicd.md
+++ b/cicd.md
@@ -20,7 +20,7 @@ And then simply run the following to deploy all containers in all shipments spec
 harbor-compose deploy
 ```
 
-If you wanted to conditionally deploy to a different environment (e.g., QA) in your build (maybe based on branch) using the same set of compose files, you could...
+If you wanted to conditionally deploy to a different environment (e.g., QA) in your build (maybe based on branch) using the same set of compose files, you could another set of environment variables to your build.
 
 ```
 $ harbor-compose buildtoken ls -e qa
@@ -205,6 +205,6 @@ Or, if you want to deploy your shipments to an environment different from the on
 $ harbor-compose buildtoken ls -e qa
 
 SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
-mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_DEV_TOKEN      ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
-mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_DEV_TOKEN   Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
+mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_QA_TOKEN       ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
+mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_QA_TOKEN    Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
 ```

--- a/cicd.md
+++ b/cicd.md
@@ -20,7 +20,7 @@ And then simply run the following to deploy all containers in all shipments spec
 harbor-compose deploy
 ```
 
-If you wanted to conditionally deploy to a different environment (e.g., QA) in your build (maybe based on branch) using the same set of compose files, you could another set of environment variables to your build.
+If you wanted to conditionally deploy to a different environment (e.g., QA) in your build (maybe based on branch) using the same set of compose files, you could add another set of environment variables to your build.
 
 ```
 $ harbor-compose buildtoken ls -e qa

--- a/cicd.md
+++ b/cicd.md
@@ -1,12 +1,17 @@
 ### Harbor Compose and CI/CD
 
-The `up` command is currently not very CI/CD friendly since it requires login credentials and uses internal-facing APIs.  That's where the `deploy` command comes in.  The `deploy` command can be used to trigger a deployment of new versions of Docker images specified in compose files (one or many shipments with one or many containers).  This works from public build services (e.g.; Circle CI, Codeship, Travis CI, etc.) by using the shipment/environment build token specified using environment variables with the naming convention, `${SHIPMENT}_${ENV}_TOKEN` (see the [buildtoken command](#The-buildtoken-command) below for how to get your build tokens).
+The `up` command is currently not very CI/CD friendly since it requires login credentials and uses internal-facing APIs.  That's where the `deploy` command comes in.  The `deploy` command can be used to trigger a deployment of new versions of Docker images specified in compose files (one or many shipments with one or many containers).  
 
-So, for example, to deploy an app with two shipments named, "mss-app-web" and "mss-app-worker" to your dev environment, you would add environment variables to your build.
+This works from public build services (e.g.; Circle CI, Codeship, Travis CI, etc.) by using the shipment/environment build token specified with environment variables with the naming convention, `${SHIPMENT}_${ENV}_TOKEN`.
+
+So, for example, to deploy an app with two shipments named, "mss-app-web" and "mss-app-worker" to your dev environment, you would add the following environment variables to your build environment (see the [buildtoken command](#the-buildtoken-command) below for more info).
 
 ```
-MSS_APP_WEB_DEV_TOKEN=xyz
-MSS_APP_WORKER_DEV_TOKEN=xyz
+$ harbor-compose buildtoken ls
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-web      dev           MSS_POC_SQS_WEB_DEV_TOKEN      3xFVlltLZ7JwPH20Km75DrpMwOk2a4yq
+mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3yuA8	
 ```
 
 And then simply run the following to deploy all containers in all shipments specified in your compose files.
@@ -18,11 +23,14 @@ harbor-compose deploy
 If you wanted to conditionally deploy to a different environment (e.g., QA) using the same set of compose files, you could...
 
 ```
-MSS_APP_WEB_QA_TOKEN=xyz
-MSS_APP_WORKER_QA_TOKEN=xyz
+$ harbor-compose buildtoken ls -e qa
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_DEV_TOKEN      ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
+mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_DEV_TOKEN   Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
 ```
 
-And then simply run
+And then run
 
 ```
 harbor-compose deploy -e qa
@@ -42,44 +50,6 @@ If you're just doing CI and not CD, you can use the `catalog` command to catalog
 docker-compose build
 docker-compose push
 harbor-compose catalog
-```
-
-#### The buildtoken command
-
-The `buildtoken` command has two sub commands.
-```
-Available Commands:
-  get         displays a build token for the requested shipment and environment
-  list        list harbor build tokens for shipments in harbor-compose.yml
-```
-
-The `list` or `ls` command.
-```
-$ harbor-compose buildtoken ls
-
-SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
-mss-poc-sqs-web      dev           MSS_POC_SQS_WEB_DEV_TOKEN      3xFVlltLZ7JwPH20Km75DrpMwOk2asdf
-mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
-```
-
-The `get` command prompts you for a shipment and environment.
-```
-$ harbor-compose buildtoken get
-
-Shipment: mss-poc-sqs-worker
-Environment: dev
-
-SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
-mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
-```
-
-Or, alternatively, you can pass the shipment and environment as args.
-```
-$ harbor-compose buildtoken get mss-poc-sqs-worker dev
-
-SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
-mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
-
 ```
 
 
@@ -190,4 +160,51 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then 
               harbor-compose deploy;
             fi
+```
+
+
+#### The buildtoken command
+
+The `buildtoken` command has two sub commands.
+```
+Available Commands:
+  get         displays a build token for the requested shipment and environment
+  list        list harbor build tokens for shipments in harbor-compose.yml
+```
+
+The `get` command prompts you for a shipment and environment.
+```
+$ harbor-compose buildtoken get
+
+Shipment: mss-poc-sqs-worker
+Environment: dev
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
+```
+
+Or, alternatively, you can pass the shipment and environment as args.
+```
+$ harbor-compose buildtoken get mss-poc-sqs-worker dev
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
+```
+
+The `list` (or `ls`) command provides the build tokens for the shipments in your harbor-compose.yml.
+```
+$ harbor-compose buildtoken ls
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-web      dev           MSS_POC_SQS_WEB_DEV_TOKEN      3xFVlltLZ7JwPH20Km75DrpMwOk2a4yq
+mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3yuA8	
+```
+
+Or, if you want to deploy your shipments to an environment different from the one that's specified in your harbor-compose.yml, you can use the following.
+```
+$ harbor-compose buildtoken ls -e qa
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_DEV_TOKEN      ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
+mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_DEV_TOKEN   Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
 ```

--- a/cicd.md
+++ b/cicd.md
@@ -20,14 +20,14 @@ And then simply run the following to deploy all containers in all shipments spec
 harbor-compose deploy
 ```
 
-If you wanted to conditionally deploy to a different environment (e.g., QA) using the same set of compose files, you could...
+If you wanted to conditionally deploy to a different environment (e.g., QA) in your build (maybe based on branch) using the same set of compose files, you could...
 
 ```
 $ harbor-compose buildtoken ls -e qa
 
 SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
-mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_DEV_TOKEN      ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
-mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_DEV_TOKEN   Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
+mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_QA_TOKEN       ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
+mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_QA_TOKEN    Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
 ```
 
 And then run

--- a/cicd.md
+++ b/cicd.md
@@ -1,6 +1,6 @@
 ### Harbor Compose and CI/CD
 
-The `up` command is currently not very CI/CD friendly since it requires login credentials and uses internal-facing APIs.  That's where the `deploy` command comes in.  The `deploy` command can be used to trigger a deployment of new versions of Docker images specified in compose files (one or many shipments with one or many containers).  This works from public build services (e.g.; Circle CI, Codeship, Travis CI, etc.) by using the shipment/environment build token specified using environment variables with the naming convention, `${SHIPMENT}_${ENV}_TOKEN`.  
+The `up` command is currently not very CI/CD friendly since it requires login credentials and uses internal-facing APIs.  That's where the `deploy` command comes in.  The `deploy` command can be used to trigger a deployment of new versions of Docker images specified in compose files (one or many shipments with one or many containers).  This works from public build services (e.g.; Circle CI, Codeship, Travis CI, etc.) by using the shipment/environment build token specified using environment variables with the naming convention, `${SHIPMENT}_${ENV}_TOKEN` (see the [buildtoken command](#The-buildtoken-command) below for how to get your build tokens).
 
 So, for example, to deploy an app with two shipments named, "mss-app-web" and "mss-app-worker" to your dev environment, you would add environment variables to your build.
 
@@ -44,16 +44,55 @@ docker-compose push
 harbor-compose catalog
 ```
 
+#### The buildtoken command
+
+The `buildtoken` command has two sub commands.
+```
+Available Commands:
+  get         displays a build token for the requested shipment and environment
+  list        list harbor build tokens for shipments in harbor-compose.yml
+```
+
+The `list` or `ls` command.
+```
+$ harbor-compose buildtoken ls
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-web      dev           MSS_POC_SQS_WEB_DEV_TOKEN      3xFVlltLZ7JwPH20Km75DrpMwOk2asdf
+mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
+```
+
+The `get` command prompts you for a shipment and environment.
+```
+$ harbor-compose buildtoken get
+
+Shipment: mss-poc-sqs-worker
+Environment: dev
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
+```
+
+Or, alternatively, you can pass the shipment and environment as args.
+```
+$ harbor-compose buildtoken get mss-poc-sqs-worker dev
+
+SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
+mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
+
+```
+
+
 #### generate --build-provider
 
 The `generate` command has a `--build-provider` flag that can help with scenarios where teams want to take existing applications running on Harbor and migrate them to various third-party build CI/CD providers.  The idea is that a `build provider` can output the compose files along with any other necessary files required to do CI/CD using a particular provider.  The following is a list of supported providers.
 
-`local`
+##### local
 
 Simply adds a docker-compose [build](https://github.com/turnerlabs/harbor-compose/blob/master/compose-reference.md#build) directive.
 
 
-`circleciv1`
+##### circleciv1
 
 This provider will output a docker-compose.yml file with a [build](https://github.com/turnerlabs/harbor-compose/blob/master/compose-reference.md#build) directive and an image tagged with a Circle CI build number.  Note that environment variables updates in Harbor are not currently supported via the public API, and are therefore not outputted.  A `harbor-compose.yml` file and a [`circle.yml`](https://circleci.com/docs/1.0/configuration/) file are also outputted and are already setup to be able to catalog and deploy new images.  You can run this command in the root of your source code repo, and after linking your repo to Circle CI, you can commit/push the files and get basic CI/CD working.  For example:
 
@@ -63,7 +102,7 @@ $ harbor-compose generate mss-my-shipment dev --build-provider circleciv1
 Be sure to supply the following environment variables in your Circle CI build:
 DOCKER_USER (registry user)
 DOCKER_PASS (registry password)
-MSS_MY_SHIPMENT_DEV_TOKEN (Harbor shipment/environment build token)
+MSS_MY_SHIPMENT_DEV_TOKEN=2N3QFkQkdilwj34ezS2JKxwt6Fn3yuA7
 
 done
 ```
@@ -111,9 +150,13 @@ deployment:
       - harbor-compose deploy		
 ```
 
-`circleciv2 (beta)`
+##### circleciv2 (beta)
 
 Same as `circleciv1` but outputs the v2 format.
+
+```
+$ harbor-compose generate mss-my-shipment dev --build-provider circleciv2
+```
 
 .circle/config.yml
 ```yaml

--- a/cmd/buildProviderCircleciv1.go
+++ b/cmd/buildProviderCircleciv1.go
@@ -9,7 +9,7 @@ import (
 type CircleCIv1 struct{}
 
 //ProvideArtifacts -
-func (provider CircleCIv1) ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose) ([]*BuildArtifact, error) {
+func (provider CircleCIv1) ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose, token string) ([]*BuildArtifact, error) {
 
 	//iterate containers
 	for _, svc := range dockerCompose.Services {
@@ -37,7 +37,8 @@ func (provider CircleCIv1) ProvideArtifacts(dockerCompose *DockerCompose, harbor
 	if harborCompose != nil {
 		for name, shipment := range harborCompose.Shipments {
 			fmt.Print(getBuildTokenName(name, shipment.Env))
-			fmt.Println(" (Harbor shipment/environment build token)")
+			fmt.Print("=")
+			fmt.Println(token)
 		}
 	}
 	fmt.Println()

--- a/cmd/buildProviderCircleciv2.go
+++ b/cmd/buildProviderCircleciv2.go
@@ -9,7 +9,7 @@ import (
 type CircleCIv2 struct{}
 
 //ProvideArtifacts -
-func (provider CircleCIv2) ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose) ([]*BuildArtifact, error) {
+func (provider CircleCIv2) ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose, token string) ([]*BuildArtifact, error) {
 
 	//iterate containers
 	for _, svc := range dockerCompose.Services {
@@ -37,7 +37,8 @@ func (provider CircleCIv2) ProvideArtifacts(dockerCompose *DockerCompose, harbor
 	if harborCompose != nil {
 		for name, shipment := range harborCompose.Shipments {
 			fmt.Print(getBuildTokenName(name, shipment.Env))
-			fmt.Println(" (Harbor shipment/environment build token)")
+			fmt.Print("=")
+			fmt.Println(token)
 		}
 	}
 	fmt.Println()

--- a/cmd/buildProviderLocal.go
+++ b/cmd/buildProviderLocal.go
@@ -4,7 +4,7 @@ package cmd
 type LocalBuild struct{}
 
 //ProvideArtifacts -
-func (provider LocalBuild) ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose) ([]*BuildArtifact, error) {
+func (provider LocalBuild) ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose, token string) ([]*BuildArtifact, error) {
 	//set build configuration to string containing a path to the build context
 	for _, svc := range dockerCompose.Services {
 		svc.Build = "."

--- a/cmd/buildProviders.go
+++ b/cmd/buildProviders.go
@@ -15,7 +15,7 @@ type BuildArtifact struct {
 type BuildProvider interface {
 
 	//build providers can manipulate the docker compose configuration and output build artifacts
-	ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose) ([]*BuildArtifact, error)
+	ProvideArtifacts(dockerCompose *DockerCompose, harborCompose *HarborCompose, token string) ([]*BuildArtifact, error)
 }
 
 //return a build provider based on its name

--- a/cmd/buildToken.go
+++ b/cmd/buildToken.go
@@ -2,10 +2,101 @@ package cmd
 
 import (
 	"fmt"
+	"html/template"
 	"log"
 	"os"
 	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
 )
+
+//BuildTokenOutput represents an object that can be written to stdout and formatted
+type BuildTokenOutput struct {
+	Shipment    string
+	Environment string
+	CiCdEnvVar  string
+	Token       string
+}
+
+func init() {
+	RootCmd.AddCommand(buildTokenCmd)
+	buildTokenCmd.AddCommand(listBuildTokensCmd)
+}
+
+// buildTokenCmd represents the buildtoken command
+var buildTokenCmd = &cobra.Command{
+	Use:   "buildtoken",
+	Short: "manage harbor build tokens",
+	Long:  `manage harbor build tokens`,
+	Run:   buildTokens,
+}
+
+// listBuildTokensCmd represents the buildtoken command
+var listBuildTokensCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "list harbor build tokens for shipments in harbor-compose.yml",
+	Long:    `list harbor build tokens for shipments in harbor-compose.yml`,
+	Run:     listBuildTokens,
+	Aliases: []string{"ls"}}
+
+func buildTokens(cmd *cobra.Command, args []string) {
+	cmd.Help()
+}
+
+func listBuildTokens(cmd *cobra.Command, args []string) {
+
+	//ensure user is logged in
+	username, token, err := Login()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//read the harbor compose file
+	harborCompose := DeserializeHarborCompose(HarborComposeFile)
+	if harborCompose.Shipments == nil || len(harborCompose.Shipments) == 0 {
+		fmt.Println("no shipments found")
+		return
+	}
+
+	//print table header
+	const padding = 3
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', tabwriter.DiscardEmptyColumns)
+	fmt.Println("")
+	fmt.Fprintln(w, "SHIPMENT\tENVIRONMENT\tCICD_ENVAR\tTOKEN\t")
+
+	//create a formatted template
+	tmpl, err := template.New("shipment-token").Parse("{{.Shipment}}\t{{.Environment}}\t{{.CiCdEnvVar}}\t{{.Token}}")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	//iterate shipments
+	for shipmentName, shipment := range harborCompose.Shipments {
+
+		//fetch the current state
+		shipmentObject := GetShipmentEnvironment(username, token, shipmentName, shipment.Env)
+
+		//build an object to pass to the template
+		output := BuildTokenOutput{
+			Shipment:    shipmentName,
+			Environment: shipment.Env,
+			CiCdEnvVar:  getBuildTokenName(shipmentName, shipment.Env),
+			Token:       shipmentObject.BuildToken,
+		}
+
+		//execute the template with the data
+		err = tmpl.Execute(w, output)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Fprintln(w)
+	}
+
+	//flush the writer
+	w.Flush()
+	fmt.Println("")
+}
 
 func getBuildTokenName(shipment string, environment string) string {
 	//SHIPMENT_ENV_TOKEN

--- a/cmd/buildToken.go
+++ b/cmd/buildToken.go
@@ -57,8 +57,8 @@ OR
 harbor-compose buildtoken ls -e qa
 
 SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
-mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_DEV_TOKEN      ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
-mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_DEV_TOKEN   Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
+mss-poc-sqs-web      qa            MSS_POC_SQS_WEB_QA_TOKEN       ihtvPrAH84ULVm6IC7LjWvXUgEhr7cnQ
+mss-poc-sqs-worker   qa            MSS_POC_SQS_WORKER_QA_TOKEN    Y3Jk0DmMaUsoWO8mbI2Edn9Ixhwj14Vd
 	`,
 	Run:     listBuildTokens,
 	Aliases: []string{"ls"}}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -108,6 +108,10 @@ func generate(cmd *cobra.Command, args []string) {
 		log.Printf("fetching shipment...")
 	}
 	shipmentObject := GetShipmentEnvironment(username, token, shipment, env)
+	if shipmentObject == nil {
+		fmt.Println("shipment not found")
+		return
+	}
 
 	//convert a Shipment object into a DockerCompose object
 	dockerCompose := transformShipmentToDockerCompose(shipmentObject)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -121,7 +121,7 @@ func generate(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		artifacts, err := provider.ProvideArtifacts(&dockerCompose, &harborCompose)
+		artifacts, err := provider.ProvideArtifacts(&dockerCompose, &harborCompose, shipmentObject.BuildToken)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -509,7 +509,7 @@ func TestTransformShipmentToDockerComposeBuildProviderLocal(t *testing.T) {
 	}
 
 	//run the build provider
-	_, err = provider.ProvideArtifacts(&dockerCompose, &harborCompose)
+	_, err = provider.ProvideArtifacts(&dockerCompose, &harborCompose, "token")
 	if err != nil {
 		t.Fail()
 	}
@@ -585,7 +585,7 @@ func TestTransformShipmentToDockerComposeBuildProviderCircleCI(t *testing.T) {
 	}
 
 	//run the build provider
-	artifacts, err := provider.ProvideArtifacts(&dockerCompose, &harborCompose)
+	artifacts, err := provider.ProvideArtifacts(&dockerCompose, &harborCompose, "token")
 	if err != nil {
 		t.Fail()
 	}
@@ -674,7 +674,7 @@ func TestTransformShipmentToDockerComposeBuildProviderCircleCIv2(t *testing.T) {
 	}
 
 	//run the build provider
-	artifacts, err := provider.ProvideArtifacts(&dockerCompose, &harborCompose)
+	artifacts, err := provider.ProvideArtifacts(&dockerCompose, &harborCompose, "token")
 	if err != nil {
 		t.Fail()
 	}

--- a/cmd/prompt.go
+++ b/cmd/prompt.go
@@ -28,6 +28,15 @@ func askForConfirmation() bool {
 	}
 }
 
+func askForString() string {
+	var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return response
+}
+
 // posString returns the first index of element in slice.
 // If slice does not contain element, returns -1.
 func posString(slice []string, element string) int {

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -57,6 +57,7 @@ type ShipmentEnvironment struct {
 		EnvVars []EnvVarPayload `json:"envVars,omitempty"`
 		Group   string          `json:"group,omitempty"`
 	}
+	BuildToken string `json:"buildToken,omitempty"`
 }
 
 // EnvVarPayload represents EnvVar


### PR DESCRIPTION
```
Available Commands:
  get         displays a build token for the requested shipment and environment
  list        list harbor build tokens for shipments in harbor-compose.yml

harbor-compose buildtoken ls

SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
mss-poc-sqs-web      dev           MSS_POC_SQS_WEB_DEV_TOKEN      3xFVlltLZ7JwPH20Km75DrpMwOk2asdf
mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf


harbor-compose buildtoken get

Shipment: mss-poc-sqs-worker
Environment: dev

SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf


harbor-compose buildtoken get mss-poc-sqs-worker dev

SHIPMENT             ENVIRONMENT   CICD_ENVAR                     TOKEN
mss-poc-sqs-worker   dev           MSS_POC_SQS_WORKER_DEV_TOKEN   2N3QFkQkdilwj34ezS2JTxwt6Fn3asdf
```