### PR TITLE
fixes ps when used with expanded compose file (closes #112)

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -5,9 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/docker/libcompose/docker"
-	"github.com/docker/libcompose/docker/ctx"
-	"github.com/docker/libcompose/project"
 	"github.com/spf13/cobra"
 )
 
@@ -37,22 +34,11 @@ func init() {
 // catalog images
 func catalog(cmd *cobra.Command, args []string) {
 
-	//read the harbor compose file
-	harborCompose := DeserializeHarborCompose(HarborComposeFile)
-
-	//use libcompose to parse yml file
-	dockerComposeProject, err := docker.NewProject(&ctx.Context{
-		Context: project.Context{
-			ComposeFiles: []string{DockerComposeFile},
-		},
-	}, nil)
-
-	if err != nil {
-		log.Fatal("error parsing compose file" + err.Error())
-	}
+	//read the compose files
+	dockerCompose, harborCompose := unmarshalComposeFiles(DockerComposeFile, HarborComposeFile)
 
 	//validate the compose file
-	_, err = dockerComposeProject.Config()
+	_, err := dockerCompose.Config()
 	if err != nil {
 		log.Fatal("error parsing compose file" + err.Error())
 	}
@@ -65,7 +51,7 @@ func catalog(cmd *cobra.Command, args []string) {
 		for _, containerName := range shipment.Containers {
 
 			//lookup the container in the list of services in the docker-compose file
-			serviceConfig, found := dockerComposeProject.GetServiceConfig(containerName)
+			serviceConfig, found := dockerCompose.GetServiceConfig(containerName)
 			if !found {
 				log.Fatal("could not find service in docker compose file")
 			}

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -10,24 +10,17 @@ import (
 	"github.com/docker/libcompose/project"
 )
 
-//unmarshal docker compose yaml
-func unmarshalDockerCompose(yamlString string) (DockerCompose, project.APIProject) {
+//unmarshal docker compose yaml string into a compose APIProject
+func unmarshalDockerCompose(yamlString string) project.APIProject {
 	if Verbose {
 		log.Printf("unmarshalDockerCompose - %v", yamlString)
 	}
 
 	yamlBits := []byte(yamlString)
 
-	//parse the docker compose file (only used for writing used by generate)
-	var dockerCompose DockerCompose
-	err := yaml.Unmarshal(yamlBits, &dockerCompose)
-	if err != nil {
-		log.Fatalf("error: %v", err)
-	}
-
 	//use libcompose to parse compose yml
 	bytes := [][]byte{yamlBits}
-	dockerComposeProject, err := docker.NewProject(&ctx.Context{
+	dockerCompose, err := docker.NewProject(&ctx.Context{
 		Context: project.Context{
 			ComposeBytes: bytes,
 			ProjectName:  "required",
@@ -37,7 +30,7 @@ func unmarshalDockerCompose(yamlString string) (DockerCompose, project.APIProjec
 		log.Fatal(err)
 	}
 
-	return dockerCompose, dockerComposeProject
+	return dockerCompose
 }
 
 //unmarshal harbor compose yaml
@@ -51,9 +44,16 @@ func unmarshalHarborCompose(yamlString string) HarborCompose {
 	return harborCompose
 }
 
-//unmarshals both docker compose and harbor compose yaml
+//unmarshals both docker compose and harbor compose yaml strings
 func unmarshalCompose(dockerComposeYaml string, harborComposeYaml string) (project.APIProject, HarborCompose) {
-	_, dc := unmarshalDockerCompose(dockerComposeYaml)
+	dc := unmarshalDockerCompose(dockerComposeYaml)
 	hc := unmarshalHarborCompose(harborComposeYaml)
+	return dc, hc
+}
+
+//unmarshals both docker compose and harbor compose yaml files
+func unmarshalComposeFiles(dockerComposeFile string, harborComposeFile string) (project.APIProject, HarborCompose) {
+	dc := DeserializeDockerCompose(dockerComposeFile)
+	hc := DeserializeHarborCompose(harborComposeFile)
 	return dc, hc
 }

--- a/cmd/dockerCompose.go
+++ b/cmd/dockerCompose.go
@@ -11,7 +11,7 @@ import (
 )
 
 // DeserializeDockerCompose deserializes a docker-compose.yml file into an object
-func DeserializeDockerCompose(file string) (DockerCompose, project.APIProject) {
+func DeserializeDockerCompose(file string) project.APIProject {
 	if Verbose {
 		log.Printf("DeserializeDockerCompose - %v", file)
 	}
@@ -23,13 +23,9 @@ func DeserializeDockerCompose(file string) (DockerCompose, project.APIProject) {
 	}
 
 	//marshal into compose objects
-	dockerCompose, dockerComposeProject := unmarshalDockerCompose(string(dockerComposeData))
+	dockerCompose := unmarshalDockerCompose(string(dockerComposeData))
 
-	if dockerCompose.Version != "2" {
-		log.Fatal("only docker-compose format v2 is supported")
-	}
-
-	return dockerCompose, dockerComposeProject
+	return dockerCompose
 }
 
 // SerializeDockerCompose serializes an object to a docker-compose.yml file

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 
+	dockerProject "github.com/docker/libcompose/project"
 	"github.com/spf13/cobra"
 )
 
@@ -114,11 +115,12 @@ func initHarborCompose(cmd *cobra.Command, args []string) {
 	if _, err := os.Stat(DockerComposeFile); err == nil {
 
 		//parse the docker compose yaml to get the list of containers
-		dockerCompose, _ := DeserializeDockerCompose(DockerComposeFile)
+		dockerCompose := DeserializeDockerCompose(DockerComposeFile)
+		proj := dockerCompose.(*dockerProject.Project)
 
 		//add all docker services as containers
-		for container := range dockerCompose.Services {
-			composeShipment.Containers = append(composeShipment.Containers, container)
+		for _, service := range proj.ServiceConfigs.Keys() {
+			composeShipment.Containers = append(composeShipment.Containers, service)
 		}
 	}
 

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -31,8 +31,7 @@ func init() {
 func ps(cmd *cobra.Command, args []string) {
 
 	//read the compose files
-	_, dockerCompose := DeserializeDockerCompose(DockerComposeFile)
-	harborCompose := DeserializeHarborCompose(HarborComposeFile)
+	dockerCompose, harborCompose := unmarshalComposeFiles(DockerComposeFile, HarborComposeFile)
 
 	doPs(dockerCompose, harborCompose)
 }

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -31,13 +31,13 @@ type HarborCompose struct {
 	Shipments map[string]ComposeShipment `yaml:"shipments"`
 }
 
-// DockerCompose represents a docker-compose.yml file
+// DockerCompose represents a docker-compose.yml file (only used for writing via generate/init)
 type DockerCompose struct {
 	Version  string                           `yaml:"version"`
 	Services map[string]*DockerComposeService `yaml:"services"`
 }
 
-// DockerComposeService represents a container (only used for writing via generate)
+// DockerComposeService represents a container (only used for writing via generate/init)
 type DockerComposeService struct {
 	Build       string            `yaml:"build,omitempty"`
 	Image       string            `yaml:"image,omitempty"`

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/docker/libcompose/docker"
-	"github.com/docker/libcompose/docker/ctx"
 	"github.com/docker/libcompose/project"
 	"github.com/spf13/cobra"
 
@@ -43,19 +41,8 @@ func up(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	//read the harbor compose file
-	harborCompose := DeserializeHarborCompose(HarborComposeFile)
-
-	//use libcompose to parse docker-compose yml file
-	dockerComposeProject, err := docker.NewProject(&ctx.Context{
-		Context: project.Context{
-			ComposeFiles: []string{DockerComposeFile},
-		},
-	}, nil)
-
-	if err != nil {
-		log.Fatal(err)
-	}
+	//read the compose files
+	dockerCompose, harborCompose := unmarshalComposeFiles(DockerComposeFile, HarborComposeFile)
 
 	//iterate shipments
 	for shipmentName, shipment := range harborCompose.Shipments {
@@ -74,11 +61,11 @@ func up(cmd *cobra.Command, args []string) {
 			if Verbose {
 				log.Println("shipment environment not found")
 			}
-			createShipment(username, token, shipmentName, shipment, dockerComposeProject)
+			createShipment(username, token, shipmentName, shipment, dockerCompose)
 
 		} else {
 			//make changes to harbor based on compose files
-			updateShipment(username, token, shipmentObject, shipmentName, shipment, dockerComposeProject)
+			updateShipment(username, token, shipmentObject, shipmentName, shipment, dockerCompose)
 		}
 
 		fmt.Println("done")

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -22,8 +22,8 @@ services:
       CHAR_EQUAL: foo=bar	
 `
 
-	_, dockerComposeProject := unmarshalDockerCompose(yaml)
-	proj, _ := dockerComposeProject.GetServiceConfig("container")
+	dockerCompose := unmarshalDockerCompose(yaml)
+	proj, _ := dockerCompose.GetServiceConfig("container")
 
 	assert.Equal(t, "foo=bar", proj.Environment.ToMap()["CHAR_EQUAL"])
 }


### PR DESCRIPTION
- closes #112
- removes all occurrences of local DockerCompose type for
  deserializing. Now only used for serializing from generate and init.
  libcompose is now exclusively used for reading docker compose file.
- adds utility function for reading both compose files in one call

Signed-off-by: John Ritsema <john.ritsema@turner.com>