### PR TITLE
Adds env command: push, pull, ls

### DIFF
--- a/cmd/dockerCompose.go
+++ b/cmd/dockerCompose.go
@@ -28,21 +28,23 @@ func DeserializeDockerCompose(file string) project.APIProject {
 	return dockerCompose
 }
 
+func marshalDockerCompose(o DockerCompose) []byte {
+	//serialize object to yaml
+	data, err := yaml.Marshal(o)
+	check(err)
+	return data
+}
+
 // SerializeDockerCompose serializes an object to a docker-compose.yml file
 func SerializeDockerCompose(dockerCompose DockerCompose, file string) {
-
-	//serialize object to yaml
-	data, err := yaml.Marshal(dockerCompose)
-	if err != nil {
-		log.Fatalf("error marshaling yaml: %v", err)
-	}
+	data := marshalDockerCompose(dockerCompose)
 
 	if Verbose {
 		log.Printf("writing docker-compose file to %v", file)
 	}
 
 	//write yaml to docker-compose.yml
-	err = ioutil.WriteFile(file, data, 0644)
+	err := ioutil.WriteFile(file, data, 0644)
 	if err != nil {
 		log.Fatalf("error writing %v: %v", DockerComposeFile, err)
 	}

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -57,48 +57,48 @@ func logShippingEnvVars() map[string]string {
 	}
 }
 
-var envvarsShipment string
-var envvarsEnvironment string
-var envvvarsHiddenFile string
-var envvvarsEnvFile string
+var envShipment string
+var envEnvironment string
+var envHiddenFile string
+var envEnvFile string
 
 func init() {
-	RootCmd.AddCommand(envvarsCmd)
+	RootCmd.AddCommand(envCmd)
 
 	//list
-	envvarsCmd.AddCommand(listEnvvarsCmd)
-	listEnvvarsCmd.PersistentFlags().StringVarP(&envvarsShipment, "shipment", "s", "", "shipment name")
-	listEnvvarsCmd.PersistentFlags().StringVarP(&envvarsEnvironment, "environment", "e", "", "environment name")
+	envCmd.AddCommand(listEnvCmd)
+	listEnvCmd.PersistentFlags().StringVarP(&envShipment, "shipment", "s", "", "shipment name")
+	listEnvCmd.PersistentFlags().StringVarP(&envEnvironment, "environment", "e", "", "environment name")
 
 	//push
-	envvarsCmd.AddCommand(pushEnvvarsCmd)
-	pushEnvvarsCmd.PersistentFlags().StringVarP(&envvarsShipment, "shipment", "s", "", "shipment name")
-	pushEnvvarsCmd.PersistentFlags().StringVarP(&envvarsEnvironment, "environment", "e", "", "environment name")
-	pushEnvvarsCmd.PersistentFlags().StringVarP(&envvvarsHiddenFile, "hidden", "", hiddenEnvFileName, "The location of the docker compose environment file that contains hidden environment variables")
+	envCmd.AddCommand(pushEnvCmd)
+	pushEnvCmd.PersistentFlags().StringVarP(&envShipment, "shipment", "s", "", "shipment name")
+	pushEnvCmd.PersistentFlags().StringVarP(&envEnvironment, "environment", "e", "", "environment name")
+	pushEnvCmd.PersistentFlags().StringVarP(&envHiddenFile, "hidden", "", hiddenEnvFileName, "The location of the docker compose environment file that contains hidden environment variables")
 
 	//pull
-	envvarsCmd.AddCommand(pullEnvvarsCmd)
-	pullEnvvarsCmd.PersistentFlags().StringVarP(&envvarsShipment, "shipment", "s", "", "shipment name")
-	pullEnvvarsCmd.PersistentFlags().StringVarP(&envvarsEnvironment, "environment", "e", "", "environment name")
-	pullEnvvarsCmd.PersistentFlags().StringVarP(&envvvarsHiddenFile, "hidden", "", hiddenEnvFileName, "The location of the docker compose environment file that contains hidden environment variables")
-	pullEnvvarsCmd.PersistentFlags().StringVarP(&envvvarsEnvFile, "env-file", "", "", "Specify a docker compose env_file to write to rather than writing directly to the docker-compose.yml environment section")
+	envCmd.AddCommand(pullEnvCmd)
+	pullEnvCmd.PersistentFlags().StringVarP(&envShipment, "shipment", "s", "", "shipment name")
+	pullEnvCmd.PersistentFlags().StringVarP(&envEnvironment, "environment", "e", "", "environment name")
+	pullEnvCmd.PersistentFlags().StringVarP(&envHiddenFile, "hidden", "", hiddenEnvFileName, "The location of the docker compose environment file that contains hidden environment variables")
+	pullEnvCmd.PersistentFlags().StringVarP(&envEnvFile, "env-file", "", "", "Specify a docker compose env_file to write to rather than writing directly to the docker-compose.yml environment section")
 }
 
-// envvarsCmd represents the envvars command
-var envvarsCmd = &cobra.Command{
-	Use:   "envvars",
+// envCmd represents the env command
+var envCmd = &cobra.Command{
+	Use:   "env",
 	Short: "manage environment variables",
 	Long:  "manage environment variables",
-	Example: `harbor-compose envvars list
-harbor-compose envvars push 
-harbor-compose envvars pull`,
+	Example: `harbor-compose env list
+harbor-compose env push 
+harbor-compose env pull`,
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
 	},
 	PreRun: preRunHook,
 }
 
-var listEnvvarsCmd = &cobra.Command{
+var listEnvCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "list harbor environment variables",
@@ -108,15 +108,15 @@ List environment and container-level environment variables for all shipment/envi
 
 Use the --shipment and --environment flags to specify a shipment/environment other than what's in the harbor-compose.yml
 `,
-	Example: `harbor-compose envvars ls
-harbor-compose envvars ls -s my-app -e dev
+	Example: `harbor-compose env ls
+harbor-compose env ls -s my-app -e dev
 `,
 	Run:    listEnvVars,
 	PreRun: preRunHook,
 }
 
-// pushEnvvarsCmd represents the envvars push command
-var pushEnvvarsCmd = &cobra.Command{
+// pushEnvCmd represents the envvars push command
+var pushEnvCmd = &cobra.Command{
 	Use:   "push",
 	Short: "push docker compose environment variables to harbor",
 	Long: `push docker compose environment variables to harbor
@@ -125,18 +125,18 @@ The push command takes all of the environment variables accessible by docker-com
 
 The push command works with a harbor-compose.yml file to push environment variables for one or many shipment/environment/containers, as well as for a single shipment environment using the --shipment and --environment flags.
 `,
-	Example: `harbor-compose envvars push
-harbor-compose envvars push -s my-shipment -e dev
+	Example: `harbor-compose env push
+harbor-compose env push -s my-shipment -e dev
 
 You can specify which env file contains your hidden environment variables using the --hidden flag (defaults to hidden.env)
-harbor-compose envvars push --hidden secrets.env
+harbor-compose env push --hidden secrets.env
 `,
 	Run:    pushEnvVars,
 	PreRun: preRunHook,
 }
 
-// pullEnvvarsCmd represents the envvars pull command
-var pullEnvvarsCmd = &cobra.Command{
+// pullEnvCmd represents the envvars pull command
+var pullEnvCmd = &cobra.Command{
 	Use:   "pull",
 	Short: "pull harbor environment variables into docker compose",
 	Long: `pull harbor environment variables into docker compose
@@ -147,15 +147,15 @@ By default, non-hidden env vars are written directly to the environment section 
 
 The pull command also takes optional --shipment and --environment flags.
 `,
-	Example: `harbor-compose envvars pull 
-harbor-compose envvars pull -s my-app -e dev
+	Example: `harbor-compose env pull 
+harbor-compose env pull -s my-app -e dev
 
 You can use the optional --env-file and --hidden flags to specify where the environment variables get written to.
-harbor-compose envvars pull --env-file public.env --hidden private.env
+harbor-compose env pull --env-file public.env --hidden private.env
 
 Specify the shipment/environment using the --shipment and --environment flags instead of a harbor-compose.yml file
-harbor-compose envvars pull --shipment my-app --environment dev
-harbor-compose envvars pull -s my-app -e dev
+harbor-compose env pull --shipment my-app --environment dev
+harbor-compose env pull -s my-app -e dev
 `,
 	Run:    pullEnvVars,
 	PreRun: preRunHook,
@@ -168,7 +168,7 @@ func listEnvVars(cmd *cobra.Command, args []string) {
 	check(err)
 
 	//determine which shipment/environments user wants to process
-	inputShipmentEnvironments, _ := getShipmentEnvironmentsFromInput(envvarsShipment, envvarsEnvironment)
+	inputShipmentEnvironments, _ := getShipmentEnvironmentsFromInput(envShipment, envEnvironment)
 
 	//iterate shipment/environments
 	for _, shipmentEnv := range inputShipmentEnvironments {
@@ -239,7 +239,7 @@ func pushEnvVars(cmd *cobra.Command, args []string) {
 	check(err)
 
 	//determine which shipment/environments user wants to process
-	inputShipmentEnvironments, harborComposeConfig := getShipmentEnvironmentsFromInput(envvarsShipment, envvarsEnvironment)
+	inputShipmentEnvironments, harborComposeConfig := getShipmentEnvironmentsFromInput(envShipment, envEnvironment)
 
 	//load docker compose file
 	dc := DeserializeDockerCompose(DockerComposeFile)
@@ -266,7 +266,7 @@ func pushEnvVars(cmd *cobra.Command, args []string) {
 			serviceConfig := getDockerComposeService(dc, container.Name)
 
 			//translate docker envvars to harbor
-			harborEnvVars := transformDockerServiceEnvVarsToHarborEnvVarsHidden(serviceConfig, envvvarsHiddenFile)
+			harborEnvVars := transformDockerServiceEnvVarsToHarborEnvVarsHidden(serviceConfig, envHiddenFile)
 			for _, envvar := range harborEnvVars {
 				if envvar.Name != "" {
 					if Verbose {
@@ -312,7 +312,7 @@ func pullEnvVars(cmd *cobra.Command, args []string) {
 	check(err)
 
 	//determine which shipment/environments user wants to process
-	inputShipmentEnvironments, localHarborCompose := getShipmentEnvironmentsFromInput(envvarsShipment, envvarsEnvironment)
+	inputShipmentEnvironments, localHarborCompose := getShipmentEnvironmentsFromInput(envShipment, envEnvironment)
 
 	//build up a DockerCompose object that we'll use for outputting docker-compose.yml
 	//this object may get services/containers from multiple shipment/environments
@@ -357,7 +357,7 @@ func pullEnvVars(cmd *cobra.Command, args []string) {
 		//add the services/containers from this shipment/env to the pulled compose object
 		//non-hidden envvars will get written to docker-compose.yml or --env-file
 		//hidden envvars will get written to --hidden
-		remoteDockerCompose, remoteHiddenEnvVars := transformShipmentToDockerComposeWithEnvFile(shipmentEnvironment, envvvarsHiddenFile)
+		remoteDockerCompose, remoteHiddenEnvVars := transformShipmentToDockerComposeWithEnvFile(shipmentEnvironment, envHiddenFile)
 
 		//track hidden envvars to be written later
 		for k, v := range remoteHiddenEnvVars {
@@ -369,14 +369,14 @@ func pullEnvVars(cmd *cobra.Command, args []string) {
 
 			//if --env-file is specified, write non-hidden envvars there and update env_file
 			//otherwise, they will get written directly to docker-compose.yml
-			if envvvarsEnvFile != "" {
+			if envEnvFile != "" {
 				for k, v := range service.Environment {
 					nonHiddenEnvVars[k] = v
 				}
 
 				//clear out environment section and add pointer to env_file
 				service.Environment = make(map[string]string)
-				service.EnvFile = append(service.EnvFile, envvvarsEnvFile)
+				service.EnvFile = append(service.EnvFile, envEnvFile)
 			}
 
 			//add this service to master compose file
@@ -395,10 +395,10 @@ func pullEnvVars(cmd *cobra.Command, args []string) {
 	outputFile(string(content), DockerComposeFile)
 
 	//write hidden env vars to --hidden
-	outputEnvFile(hiddenEnvVars, envvvarsHiddenFile)
+	outputEnvFile(hiddenEnvVars, envHiddenFile)
 
 	//write non-hidden envvars to --env-file
-	outputEnvFile(nonHiddenEnvVars, envvvarsEnvFile)
+	outputEnvFile(nonHiddenEnvVars, envEnvFile)
 
 	fmt.Println("done")
 }

--- a/cmd/envvars.go
+++ b/cmd/envvars.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"fmt"
+	"log"
 	"strings"
+
+	"github.com/docker/libcompose/config"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -45,6 +50,124 @@ func logShippingEnvVars() map[string]string {
 		envVarNameRegion:       envVarNameRegion,
 		envVarNameQueueName:    envVarNameQueueName,
 	}
+}
+
+var envvarsShipment string
+var envvarsEnvironment string
+var envvvarsHiddenFile string
+var envvvarsEnvFile string
+
+func init() {
+	RootCmd.AddCommand(envvarsCmd)
+
+	//push
+	envvarsCmd.AddCommand(pushEnvvarsCmd)
+	pushEnvvarsCmd.PersistentFlags().StringVarP(&envvarsShipment, "shipment", "s", "", "shipment name")
+	pushEnvvarsCmd.PersistentFlags().StringVarP(&envvarsEnvironment, "environment", "e", "", "environment name")
+	pushEnvvarsCmd.PersistentFlags().StringVarP(&envvvarsHiddenFile, "hidden", "", hiddenEnvFileName, "The location of the docker compose environment file that contains hidden environment variables")
+}
+
+// envvarsCmd represents the envvars command
+var envvarsCmd = &cobra.Command{
+	Use:   "envvars",
+	Short: "manage environment variables",
+	Long:  "manage environment variables",
+	Example: `harbor-compose envvars push 
+harbor-compose envvars pull`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+	PreRun: preRunHook,
+}
+
+// pushEnvvarsCmd represents the envvars push command
+var pushEnvvarsCmd = &cobra.Command{
+	Use:   "push",
+	Short: "push docker compose environment variables to harbor",
+	Long: `push docker compose environment variables to harbor
+
+The push command works with a harbor-compose.yml file to push environment variables for one or many shipment/environment/containers, as well as for a single shipment environment using the --shipment and --environment flags.
+`,
+	Example: `harbor-compose push
+harbor-compose push -s my-shipment -e dev
+
+You can specify which env file contains your hidden environment variables using the --hidden flag (defaults to hidden.env)
+harbor-compose push --hidden my-hidden.env
+`,
+	Run: pushEnvVars,
+}
+
+func pushEnvVars(cmd *cobra.Command, args []string) {
+
+	//make sure user is authenticated
+	username, token, err := Login()
+	check(err)
+
+	//determine which shipment/environments user wants to process
+	inputShipmentEnvironments, harborComposeConfig := getShipmentEnvironmentsFromInput(envvarsShipment, envvarsEnvironment)
+
+	//load docker compose file
+	dc := DeserializeDockerCompose(DockerComposeFile)
+
+	//iterate shipment/environments
+	for _, t := range inputShipmentEnvironments {
+		shipment := t.Item1
+		env := t.Item2
+
+		//lookup the shipment environment
+		shipmentEnvironment := GetShipmentEnvironment(username, token, shipment, env)
+		if shipmentEnvironment == nil {
+			fmt.Println(messageShipmentEnvironmentNotFound)
+			return
+		}
+
+		//iterate containers
+		for _, container := range shipmentEnvironment.Containers {
+			if Verbose {
+				log.Printf("processing container: %v", container.Name)
+			}
+
+			//lookup the container in the list of services in the docker-compose file
+			serviceConfig := getDockerComposeService(dc, container.Name)
+
+			//translate docker envvars to harbor
+			harborEnvVars := transformDockerServiceEnvVarsToHarborEnvVarsHidden(serviceConfig, envvvarsHiddenFile)
+			for _, envvar := range harborEnvVars {
+				if envvar.Name != "" {
+					if Verbose {
+						log.Printf("processing %s (%s)", envvar.Name, envvar.Type)
+					}
+
+					//save the envvar
+					SaveEnvVar(username, token, shipment, env, envvar, container.Name)
+				}
+			}
+		}
+
+		//only process environment-level env vars if using a harbor-compose.yml file
+		if harborComposeConfig != nil {
+			if Verbose {
+				log.Println("looking for harbor-compose.yml envvars")
+			}
+
+			//lookup current shipment in harbor-compose.yml
+			for evName, evValue := range harborComposeConfig.Shipments[shipment].Environment {
+				if Verbose {
+					log.Println("processing " + evName)
+				}
+
+				//translate to a a harbor basic env var
+				envVarPayload := envVar(evName, evValue)
+
+				//save the envvar
+				SaveEnvVar(username, token, shipment, env, envVarPayload, "")
+
+			} //envvars
+		}
+	}
+
+	fmt.Println("done")
+	fmt.Println("run 'up' or 'deploy' for the environment variable changes to take effect")
 }
 
 //processes envvars by copying them to a destination and filtering out special and hidden envvars
@@ -101,4 +224,66 @@ func envVarHidden(name string, value string) EnvVarPayload {
 		Value: value,
 		Type:  "hidden",
 	}
+}
+
+//transform a docker service's environment variables into harbor-specific env var objects
+func transformDockerServiceEnvVarsToHarborEnvVars(dockerService *config.ServiceConfig) []EnvVarPayload {
+	return transformDockerServiceEnvVarsToHarborEnvVarsHidden(dockerService, hiddenEnvFileName)
+}
+
+//transform a docker service's environment variables into harbor-specific env var objects
+func transformDockerServiceEnvVarsToHarborEnvVarsHidden(dockerService *config.ServiceConfig, hiddenEnvVarFileName string) []EnvVarPayload {
+
+	//docker-compose.yml
+	//env_file:
+	//- hidden.env
+	//
+	//gets mapped to type=hidden
+	//everything else type=basic
+
+	harborEnvVars := []EnvVarPayload{}
+
+	//container-level env vars (note that these are parsed by libcompose which supports:
+	//environment, env_file, and variable substitution with .env)
+	containerEnvVars := dockerService.Environment.ToMap()
+
+	//has the user specified hidden env vars in a hidden.env?
+	if Verbose {
+		log.Printf("Looking for hidden environment variables in %s \n", hiddenEnvVarFileName)
+	}
+	hiddenEnvVars := false
+	hiddenEnvVarFile := ""
+	for _, envFileName := range dockerService.EnvFile {
+		if strings.HasSuffix(envFileName, hiddenEnvVarFileName) {
+			hiddenEnvVars = true
+			hiddenEnvVarFile = envFileName
+			if Verbose {
+				log.Println("Found hidden environment variable file: " + hiddenEnvVarFile)
+			}
+			break
+		}
+	}
+
+	//iterate/process hidden envvars and remove them from the list
+	if hiddenEnvVars {
+		for _, name := range parseEnvVarNames(hiddenEnvVarFile) {
+			if Verbose {
+				log.Println("processing " + name)
+			}
+			harborEnvVars = append(harborEnvVars, envVarHidden(name, containerEnvVars[name]))
+			delete(containerEnvVars, name)
+		}
+	}
+
+	//iterate/process envvars (hidden have already filtered out)
+	for name, value := range containerEnvVars {
+		if name != "" {
+			if Verbose {
+				log.Println("processing " + name)
+			}
+			harborEnvVars = append(harborEnvVars, envVar(name, value))
+		}
+	}
+
+	return harborEnvVars
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -136,7 +136,7 @@ func generate(cmd *cobra.Command, args []string) {
 			yes = askForConfirmation()
 		}
 		if yes {
-			writeHiddenEnvFile(hiddenEnvVars, hiddenEnvFileName)
+			writeEnvFile(hiddenEnvVars, hiddenEnvFileName)
 			fmt.Println("wrote " + hiddenEnvFileName)
 		}
 
@@ -154,7 +154,10 @@ func generate(cmd *cobra.Command, args []string) {
 	fmt.Println("done")
 }
 
-func writeHiddenEnvFile(envvars map[string]string, file string) {
+func writeEnvFile(envvars map[string]string, file string) {
+	if Verbose {
+		fmt.Printf("writing %v env vars to %v \n", len(envvars), file)
+	}
 	contents := ""
 	for name, value := range envvars {
 		contents += fmt.Sprintf("%s=%s\n", name, value)
@@ -222,6 +225,12 @@ func transformShipmentToHarborCompose(shipmentObject *ShipmentEnvironment) Harbo
 //transforms a ShipmentEnvironment object to its DockerCompose representation
 //(along with hidden env vars)
 func transformShipmentToDockerCompose(shipmentObject *ShipmentEnvironment) (DockerCompose, map[string]string) {
+	return transformShipmentToDockerComposeWithEnvFile(shipmentObject, hiddenEnvFileName)
+}
+
+//transforms a ShipmentEnvironment object to its DockerCompose representation
+//(along with hidden env vars)
+func transformShipmentToDockerComposeWithEnvFile(shipmentObject *ShipmentEnvironment, hiddenEnvFile string) (DockerCompose, map[string]string) {
 
 	hiddenEnvVars := map[string]string{}
 
@@ -270,7 +279,7 @@ func transformShipmentToDockerCompose(shipmentObject *ShipmentEnvironment) (Dock
 
 		//write hidden env vars to file specified in env_file
 		if len(hiddenEnvVars) > 0 {
-			service.EnvFile = []string{hiddenEnvFileName}
+			service.EnvFile = []string{hiddenEnvFile}
 		}
 
 		//add service to list

--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -325,7 +325,7 @@ func Trigger(shipment string, env string) (bool, []string) {
 }
 
 // SaveEnvVar updates an environment variable in harbor (supports both environment and container levels)
-func SaveEnvVar(username string, token string, shipment string, composeShipment ComposeShipment, envVarPayload EnvVarPayload, container string) {
+func SaveEnvVar(username string, token string, shipment string, environment string, envVarPayload EnvVarPayload, container string) {
 	var config = GetConfig()
 
 	//first, issue a GET to check if the var exists
@@ -340,7 +340,7 @@ func SaveEnvVar(username string, token string, shipment string, composeShipment 
 
 	values := make(map[string]interface{})
 	values["shipment"] = shipment
-	values["env"] = composeShipment.Env
+	values["env"] = environment
 	values["envvar"] = envVarPayload.Name
 	values["container"] = container
 

--- a/cmd/harborCompose.go
+++ b/cmd/harborCompose.go
@@ -20,21 +20,24 @@ func DeserializeHarborCompose(file string) HarborCompose {
 	return unmarshalHarborCompose(string(harborComposeData))
 }
 
+func marshalHarborCompose(o HarborCompose) []byte {
+	//serialize object to yaml
+	data, err := yaml.Marshal(o)
+	check(err)
+	return data
+}
+
 // SerializeHarborCompose serializes an object to a harbor-compose.yml file
 func SerializeHarborCompose(harborCompose HarborCompose, file string) {
 
-	//serialize object to yaml
-	data, err := yaml.Marshal(harborCompose)
-	if err != nil {
-		log.Fatalf("error marshaling yaml: %v", err)
-	}
+	data := marshalHarborCompose(harborCompose)
 
 	if Verbose {
 		log.Printf("writing harbor-compose file to %v", file)
 	}
 
 	//write yaml to harbor-compose.yml
-	err = ioutil.WriteFile(file, data, 0644)
+	err := ioutil.WriteFile(file, data, 0644)
 	if err != nil {
 		log.Fatalf("error writing %v: %v", HarborComposeFile, err)
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -66,7 +66,7 @@ func logs(cmd *cobra.Command, args []string) {
 	check(err)
 
 	//determine which shipment/environments user wants logs for
-	inputShipmentEnvironments := getShipmentEnvironmentsFromInput(logsShipment, logsEnvironment)
+	inputShipmentEnvironments, _ := getShipmentEnvironmentsFromInput(logsShipment, logsEnvironment)
 
 	//iterate shipment/environments
 	for _, t := range inputShipmentEnvironments {

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -40,7 +40,7 @@ func ps(cmd *cobra.Command, args []string) {
 	check(err)
 
 	//determine which shipment/environments user wants status for
-	inputShipmentEnvironments := getShipmentEnvironmentsFromInput(psShipment, psEnvironment)
+	inputShipmentEnvironments, _ := getShipmentEnvironmentsFromInput(psShipment, psEnvironment)
 
 	//iterate shipment/environments
 	for _, t := range inputShipmentEnvironments {

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -44,7 +44,7 @@ func restart(cmd *cobra.Command, args []string) {
 		}
 
 		//update env var
-		SaveEnvVar(username, token, shipmentName, shipment, envVar, shipment.Containers[0])
+		SaveEnvVar(username, token, shipmentName, shipment.Env, envVar, shipment.Containers[0])
 
 		//trigger
 		Trigger(shipmentName, shipment.Env)

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -20,13 +20,13 @@ type HarborCompose struct {
 // ComposeShipment represents a harbor shipment in a harbor-compose.yml file
 type ComposeShipment struct {
 	Env                        string            `yaml:"env"`
-	Barge                      string            `yaml:"barge"`
+	Barge                      string            `yaml:"barge,omitempty"`
 	Containers                 []string          `yaml:"containers"`
-	Replicas                   int               `yaml:"replicas"`
-	Group                      string            `yaml:"group"`
-	Property                   string            `yaml:"property"`
-	Project                    string            `yaml:"project"`
-	Product                    string            `yaml:"product"`
+	Replicas                   int               `yaml:"replicas,omitempty"`
+	Group                      string            `yaml:"group,omitempty"`
+	Property                   string            `yaml:"property,omitempty"`
+	Project                    string            `yaml:"project,omitempty"`
+	Product                    string            `yaml:"product,omitempty"`
 	Environment                map[string]string `yaml:"environment,omitempty"`
 	IgnoreImageVersion         bool              `yaml:"ignoreImageVersion,omitempty"`
 	EnableMonitoring           *bool             `yaml:"enableMonitoring,omitempty"`
@@ -78,7 +78,7 @@ type terraformLogShipping struct {
 	SqsQueueName               string
 }
 
-// DockerCompose represents a docker-compose.yml file (only used for writing via generate/init)
+// DockerCompose represents a docker-compose.yml file (only used for writing via generate/init/pull)
 type DockerCompose struct {
 	Version  string                           `yaml:"version"`
 	Services map[string]*DockerComposeService `yaml:"services"`

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -97,7 +97,7 @@ func findEnvVar(name string, envVars []EnvVarPayload) EnvVarPayload {
 //returns a tuple slice containing shipment/environments from user input (cli flags or compose file)
 func getShipmentEnvironmentsFromInput(shipmentFlag string, envFlag string) ([]tuple, *HarborCompose) {
 	result := []tuple{}
-	var hc HarborCompose
+	var hc *HarborCompose
 
 	//either use the shipment/environment flags or the yaml file
 	if shipmentFlag != "" && envFlag != "" {
@@ -108,11 +108,12 @@ func getShipmentEnvironmentsFromInput(shipmentFlag string, envFlag string) ([]tu
 		check(errors.New(messageShipmentEnvironmentFlagsRequired))
 	} else {
 		//read the compose file to get the shipment/environment list
-		hc = DeserializeHarborCompose(HarborComposeFile)
+		harborComposeConfig := DeserializeHarborCompose(HarborComposeFile)
+		hc = &harborComposeConfig
 		for shipmentName, shipment := range hc.Shipments {
 			result = append(result, tuple{Item1: shipmentName, Item2: shipment.Env})
 		}
 	}
 
-	return result, &hc
+	return result, hc
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -95,8 +95,9 @@ func findEnvVar(name string, envVars []EnvVarPayload) EnvVarPayload {
 }
 
 //returns a tuple slice containing shipment/environments from user input (cli flags or compose file)
-func getShipmentEnvironmentsFromInput(shipmentFlag string, envFlag string) []tuple {
+func getShipmentEnvironmentsFromInput(shipmentFlag string, envFlag string) ([]tuple, *HarborCompose) {
 	result := []tuple{}
+	var hc HarborCompose
 
 	//either use the shipment/environment flags or the yaml file
 	if shipmentFlag != "" && envFlag != "" {
@@ -107,11 +108,11 @@ func getShipmentEnvironmentsFromInput(shipmentFlag string, envFlag string) []tup
 		check(errors.New(messageShipmentEnvironmentFlagsRequired))
 	} else {
 		//read the compose file to get the shipment/environment list
-		hc := DeserializeHarborCompose(HarborComposeFile)
+		hc = DeserializeHarborCompose(HarborComposeFile)
 		for shipmentName, shipment := range hc.Shipments {
 			result = append(result, tuple{Item1: shipmentName, Item2: shipment.Env})
 		}
 	}
 
-	return result
+	return result, &hc
 }


### PR DESCRIPTION
### push scenarios
- works better with terraform so you don't have to maintain a full/duplicate hc.yml to run up
- stage envvars without deploying
```
harbor-compose envvars push
harbor-compose envvars push [--hidden secrets.env]
harbor-compose envvars push [-s app -e dev]
```

### pull scenarios
- already have compose files and want to update hidden.env from another colleague
```
harbor-compose envvars pull
```
- want to test a different environment like QA, and don't have any files (or only a docker-compose.yml)
```
harbor-compose envvars pull -s my-app -e qa --env-file qa.env
```

### list

```
harbor-compose envvars ls

SHIPMENT: my-app
ENVIRONMENT: dev

NAME            VALUE                                        TYPE
LOGS_ENDPOINT   https://listener.logz.io:8071?token=xxxxxx   hidden
SHIP_LOGS       true                                         hidden

CONTAINER: my-container

NAME          VALUE     TYPE
FOO           bar       basic
HEALTHCHECK   /health   basic
PORT          5000      basic
```