### PR TITLE
adds aws role support to init (closes #174)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,8 @@ node_modules
 .glide
 build-debug.sh
 package-lock.json
-hidden.env
 main.tf
+hidden.env
 .terraform
 terraform.tfstate
 terraform.tfstate.backup

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ node_modules
 .glide
 build-debug.sh
 package-lock.json
+hidden.env
+main.tf
+.terraform
+terraform.tfstate
+terraform.tfstate.backup

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -110,7 +110,7 @@ func generate(cmd *cobra.Command, args []string) {
 	//if the --terraform flag is specified, output a main.tf file
 	//and output a simplified harbor-compose.yml
 	if generateTerraform {
-		generateAndWriteTerraformSource(shipmentObject, &harborCompose, true)
+		generateAndWriteTerraformSource(shipmentObject, &harborCompose, true, false, "")
 
 		// reset duplicate properties (already in main.tf)
 		harborCompose = minimalHarborCompose(harborCompose)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -149,12 +149,21 @@ func initHarborCompose(cmd *cobra.Command, args []string) {
 	healthcheckTimeoutSeconds, _ := strconv.Atoi(hcTimeout)
 	healthcheckIntervalSeconds, _ := strconv.Atoi(hcInterval)
 	var err error
+	useRole := ""
+	samlUser := ""
 
 	//ask questions for harbor-compose.yml
 	if !yesUseDefaults {
 		name = promptAndGetResponse("shipment name: (e.g., mss-harbor-app) ", randomName)
 		env = promptAndGetResponse("shipment environment: (dev, qa, prod, etc.) ", env)
 		barge = promptAndGetResponse("barge: (digital-sandbox, ent-prod, corp-sandbox, corp-prod, news, nba) ", barge)
+		useRole = promptAndGetResponse("would like you to use an AWS IAM Role? (y|n) ", "n")
+		if useRole == "y" || useRole == "Y" {
+			samlUser = promptAndGetResponse("which SAML user would you like to grant role access to? (e.g., aws-digital-sandbox-devops/First.Last@turner.com) ", "")
+			if samlUser == "" {
+				check(errors.New(messageSamlUserRequired))
+			}
+		}
 		replicas = promptAndGetResponse("how many container instances: (e.g., 4) ", replicas)
 		intReplicas, err = strconv.Atoi(replicas)
 		if err != nil {
@@ -225,7 +234,8 @@ func initHarborCompose(cmd *cobra.Command, args []string) {
 	shipmentEnvironment := transformComposeToShipmentEnvironment(name, composeShipment, dockerComposeProj)
 
 	//generate a main.tf and write it to disk
-	generateAndWriteTerraformSource(&shipmentEnvironment, &harborCompose, false)
+	role := (useRole == "y" || useRole == "Y")
+	generateAndWriteTerraformSource(&shipmentEnvironment, &harborCompose, false, role, samlUser)
 
 	// remove duplicate properties (already in main.tf)
 	harborCompose = minimalHarborCompose(harborCompose)

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -19,4 +19,5 @@ const (
 	messageChangeHealthCheck                = "healthcheck changes involve downtime.  Please run the 'down --delete' command first"
 	messageChangeContainer                  = "container changes involve downtime.  Please run the 'down --delete' command first"
 	messageShipmentEnvironmentFlagsRequired = "both --shipment and --environment flags are required"
+	messageSamlUserRequired = "Please specify a federated SAML user in the form role/email (e.g.; aws-digital-sandbox-devops/First.Last@turner.com)"
 )

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -19,5 +19,5 @@ const (
 	messageChangeHealthCheck                = "healthcheck changes involve downtime.  Please run the 'down --delete' command first"
 	messageChangeContainer                  = "container changes involve downtime.  Please run the 'down --delete' command first"
 	messageShipmentEnvironmentFlagsRequired = "both --shipment and --environment flags are required"
-	messageSamlUserRequired = "Please specify a federated SAML user in the form role/email (e.g.; aws-digital-sandbox-devops/First.Last@turner.com)"
+	messageSamlUserRequired                 = "Please specify a federated SAML user in the form role/email (e.g.; aws-digital-sandbox-devops/First.Last@turner.com)"
 )

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -68,7 +68,7 @@ func terraform(cmd *cobra.Command, args []string) {
 func generateAndWriteTerraformSource(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose, printUsage bool, outputRole bool, samlUser string) {
 
 	//package the data to make it easy for rendering
-	data := getTerraformData(shipmentEnvironment, harborCompose, outputRole, samlUser)
+	data := getTerraformDataWithRole(shipmentEnvironment, harborCompose, outputRole, samlUser)
 
 	//translate a shipit shipment environment into terraform source
 	tfCode := generateTerraformSourceCode(data)
@@ -95,7 +95,11 @@ func generateAndWriteTerraformSource(shipmentEnvironment *ShipmentEnvironment, h
 	}
 }
 
-func getTerraformData(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose, role bool, samlUser string) *terraformShipmentEnvironment {
+func getTerraformData(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose) *terraformShipmentEnvironment {
+  return getTerraformDataWithRole(shipmentEnvironment, harborCompose, false, "")
+}
+
+func getTerraformDataWithRole(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose, role bool, samlUser string) *terraformShipmentEnvironment {
 
 	composeShipment := harborCompose.Shipments[shipmentEnvironment.ParentShipment.Name]
 	monitored := true

--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -60,15 +60,15 @@ func terraform(cmd *cobra.Command, args []string) {
 	harborCompose := transformShipmentToHarborCompose(shipmentObject)
 
 	//generate a main.tf and write it to disk
-	generateAndWriteTerraformSource(shipmentObject, &harborCompose, true)
+	generateAndWriteTerraformSource(shipmentObject, &harborCompose, true, false, "")
 
 	fmt.Println("done")
 }
 
-func generateAndWriteTerraformSource(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose, printUsage bool) {
+func generateAndWriteTerraformSource(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose, printUsage bool, outputRole bool, samlUser string) {
 
 	//package the data to make it easy for rendering
-	data := getTerraformData(shipmentEnvironment, harborCompose)
+	data := getTerraformData(shipmentEnvironment, harborCompose, outputRole, samlUser)
 
 	//translate a shipit shipment environment into terraform source
 	tfCode := generateTerraformSourceCode(data)
@@ -95,12 +95,18 @@ func generateAndWriteTerraformSource(shipmentEnvironment *ShipmentEnvironment, h
 	}
 }
 
-func getTerraformData(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose) *terraformShipmentEnvironment {
+func getTerraformData(shipmentEnvironment *ShipmentEnvironment, harborCompose *HarborCompose, role bool, samlUser string) *terraformShipmentEnvironment {
 
 	composeShipment := harborCompose.Shipments[shipmentEnvironment.ParentShipment.Name]
 	monitored := true
 	if composeShipment.EnableMonitoring != nil {
 		monitored = *composeShipment.EnableMonitoring
+	}
+
+	awsProfile := "default"
+	awsProfileEnv := os.Getenv("AWS_PROFILE")
+	if awsProfileEnv != "" {
+		awsProfile = awsProfileEnv
 	}
 
 	result := terraformShipmentEnvironment{
@@ -112,6 +118,9 @@ func getTerraformData(shipmentEnvironment *ShipmentEnvironment, harborCompose *H
 		Monitored:   monitored,
 		Containers:  []terraformContainer{},
 		LogShipping: terraformLogShipping{},
+		Role:        role,
+		AwsProfile:  awsProfile,
+		SamlUser:    samlUser,
 	}
 
 	for _, c := range shipmentEnvironment.Containers {
@@ -200,19 +209,19 @@ resource "harbor_shipment" "app" {
 }
 
 resource "harbor_shipment_env" "{{ .Env }}" {
-  shipment    = "${harbor_shipment.app.id}"
+  shipment    = "${harbor_shipment.app.shipment}"
   environment = "{{ .Env }}"
-  barge       = "{{ .Barge }}"
+	barge       = "{{ .Barge }}"
   replicas    = {{ .Replicas }}
 	monitored   = {{ .Monitored }}
+	{{ if .Role }}iam_role    = "${aws_iam_role.app_role.arn}"{{ end }}	
 	{{ range .Containers }}
 	container {
-		{{ if .Primary }}
-		name = "{{ .Name }}"
-		{{ else }}
+		{{ if .Primary }}name = "{{ .Name }}"{{ else }}
 		name    = "{{ .Name }}"
 		primary = false		
-		{{ end }}{{ range .Ports }}
+		{{ end }}
+		{{ range .Ports }}
     port {
 			protocol              = "{{ .Protocol }}"
 			public_port           = {{ .PublicPort }}
@@ -242,6 +251,63 @@ resource "harbor_shipment_env" "{{ .Env }}" {
 output "dns_name" {
   value = "${harbor_shipment_env.{{ .Env }}.dns_name}"
 }
+{{ if .Role }}
+provider "aws" {
+  profile = "{{ .AwsProfile }}"
+}
+
+# todo: fill out custom aws role policy
+resource "aws_iam_role_policy" "aws_access" {
+  name = "{{ .Shipment }}-{{ .Env }}"
+  role = "${aws_iam_role.app_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [],
+      "Resource": []
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role" "app_role" {
+  name               = "{{ .Shipment }}-{{ .Env }}"
+  assume_role_policy = "${data.aws_iam_policy_document.harbor_policy.json}"
+}
+
+module "harbor" {
+  source = "git::ssh://git@github.com/turnercode/harbor-terraform?ref=v1.6"
+  barge  = "{{ .Barge }}"
+}
+
+data "aws_caller_identity" "current" {}
+
+# allow role to be assumed by harbor and saml user (for local dev)
+data "aws_iam_policy_document" "harbor_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    principals {
+      type = "AWS"
+
+      identifiers = [
+        "${module.harbor.iam_role}",
+        "arn:aws:sts::${data.aws_caller_identity.current.account_id}:assumed-role/{{ .SamlUser }}",
+      ]
+    }
+  }
+}
+{{ end }}
 `
 
 	//create a formatted template

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -44,6 +44,9 @@ type terraformShipmentEnvironment struct {
 	Monitored   bool
 	Containers  []terraformContainer
 	LogShipping terraformLogShipping
+	Role        bool
+	AwsProfile  string
+	SamlUser    string
 }
 
 type terraformContainer struct {


### PR DESCRIPTION
```
harbor-compose init
...
would like you to use an AWS IAM Role? (y|n) y
which SAML user would you like to grant role access to? (e.g., aws-digital-sandbox-devops/First.Last@turner.com) 

# add aws resources to main.tf
terraform apply
```

- add newly created role to `docker-compose.yml`
```
  role:
    image: quay.io/turner/ectou-metadata
    ports:
    - 9000:80
    environment:

      # the role you want your container to assume
      ROLE: arn:aws:iam::123456789:role/my-role

      # the local profile you want to use to assume the role
      AWS_PROFILE: ${AWS_PROFILE}
```
- `docker-compose up` to test locally in docker
- `harbor-compose deploy`