### PR TITLE
adds events command (closes #118)

### DIFF
--- a/cmd/events.go
+++ b/cmd/events.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+
+	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+)
+
+// eventsCmd represents the events command
+var eventsCmd = &cobra.Command{
+	Use:   "events",
+	Short: "Show container orchestration events",
+	Long:  "Show container orchestration events for the shipment environments in your yaml files or specified via command line arguments",
+	Example: `harbor-compose events
+harbor-compose events --type all
+
+# show only normal events
+harbor-compose events --type normal
+
+# show only warning events
+harbor-compose events --type warning
+
+# show full event messages
+hargor-compose events -m
+
+# show events for a particular shipment environment
+harbor-compose events --shipment my-shipment --environment dev
+harbor-compose events -s my-shipment -e dev
+`,
+	Run:    runEvents,
+	PreRun: preRunHook,
+}
+
+var eventsShipment string
+var eventsEnvironment string
+var eventsType string
+var eventsFullMessage bool
+
+func init() {
+	eventsCmd.PersistentFlags().StringVarP(&eventsShipment, "shipment", "s", "", "shipment name")
+	eventsCmd.PersistentFlags().StringVarP(&eventsEnvironment, "environment", "e", "", "environment name")
+	eventsCmd.PersistentFlags().StringVarP(&eventsType, "type", "t", "all", "specify what level of events you would like to see (normal, warning, or all)")
+	eventsCmd.PersistentFlags().BoolVarP(&eventsFullMessage, "message", "m", false, "include the full message")
+	RootCmd.AddCommand(eventsCmd)
+}
+
+// events your shipment
+func runEvents(cmd *cobra.Command, args []string) {
+
+	//make sure user is authenticated
+	username, token, err := Login()
+	check(err)
+
+	//determine which shipment/environments user wants status for
+	inputShipmentEnvironments, _ := getShipmentEnvironmentsFromInput(eventsShipment, eventsEnvironment)
+
+	//iterate shipment/environments
+	for _, t := range inputShipmentEnvironments {
+		shipment := t.Item1
+		env := t.Item2
+
+		//lookup the shipment environment
+		shipmentEnvironment := GetShipmentEnvironment(username, token, shipment, env)
+		if shipmentEnvironment == nil {
+			fmt.Println(messageShipmentEnvironmentNotFound)
+			return
+		}
+
+		//lookup the provider
+		provider := ec2Provider(shipmentEnvironment.Providers)
+
+		//fetch events from helmit
+		events := GetShipmentEvents(provider.Barge, shipment, env)
+
+		//sort by LastTimestamp (the last time this event happened)
+		sort.Slice(events.Events, func(i, j int) bool {
+			return events.Events[i].LastTimestamp.After(events.Events[j].LastTimestamp)
+		})
+
+		//render
+		if len(events.Events) > 0 {
+
+			if eventsFullMessage {
+				printShipmentEventMessages(events)
+			} else {
+				printShipmentEvents(events)
+			}
+			fmt.Println("-----")
+
+		} else {
+			fmt.Println("no events found")
+			fmt.Println()
+			fmt.Println("note that events only occur around a deployment or an unhealthy application and eventually disappear when an app becomes healthy")
+		}
+	}
+}
+
+func printShipmentEvents(events *ShipmentEventResult) {
+	const padding = 3
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, padding, ' ', tabwriter.DiscardEmptyColumns)
+
+	fmt.Println()
+	fmt.Fprintln(w, "TYPE\tREASON\tMESSAGE\tTIME\tCOUNT")
+
+	//create a formatted template
+	tmpl, err := template.New("events").Parse("{{.Type}}\t{{.Reason}}\t{{.Message}}\t{{.StartTime}}\t{{.Count}}\t")
+	check(err)
+
+	for _, event := range events.Events {
+
+		//filter events for specified type
+		if strings.ToLower(eventsType) != "all" && strings.ToLower(eventsType) != strings.ToLower(event.Type) {
+			continue
+		}
+
+		event.StartTime = humanize.Time(event.LastTimestamp)
+
+		//truncate message
+		if !eventsFullMessage {
+			truncatedLength := 60
+			if len(event.Message) > truncatedLength {
+				event.Message = event.Message[:truncatedLength]
+			}
+		}
+
+		//execute the template with the data
+		err = tmpl.Execute(w, event)
+		check(err)
+		fmt.Fprintln(w)
+	}
+	w.Flush()
+}
+
+func printShipmentEventMessages(events *ShipmentEventResult) {
+	fmt.Println()
+	for _, event := range events.Events {
+
+		//filter events for specified type
+		if strings.ToLower(eventsType) != "all" && strings.ToLower(eventsType) != strings.ToLower(event.Type) {
+			continue
+		}
+
+		fmt.Printf("%s - %s\n", event.Reason, event.Message)
+		fmt.Println()
+	}
+}

--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -233,6 +233,38 @@ func GetLogStreamer(streamer string) (reader *bufio.Reader, err error) {
 	return
 }
 
+// GetShipmentEvents returns a ShipmentEventResult for a given shipment/environment
+func GetShipmentEvents(barge string, shipment string, env string) *ShipmentEventResult {
+
+	uri := helmitURI("/shipment/events/{barge}/{shipment}/{env}",
+		param("barge", barge),
+		param("shipment", shipment),
+		param("env", env))
+
+	if Verbose {
+		fmt.Println("fetching: " + uri)
+	}
+
+	res, body, err := gorequest.New().
+		Get(uri).
+		EndBytes()
+
+	if err != nil {
+		check(err[0])
+	}
+
+	if res.StatusCode != http.StatusOK {
+		log.Fatal("GetShipmentEvents returned ", res.StatusCode)
+	}
+
+	//deserialize json into object
+	var result ShipmentEventResult
+	unmarshalErr := json.Unmarshal(body, &result)
+	check(unmarshalErr)
+
+	return &result
+}
+
 // GetShipmentStatus returns the running status of a shipment
 func GetShipmentStatus(barge string, shipment string, env string) *ShipmentStatus {
 

--- a/cmd/helmitTypes.go
+++ b/cmd/helmitTypes.go
@@ -1,6 +1,8 @@
 package cmd
 
-import "time"
+import (
+	"time"
+)
 
 // HelmitContainer represents a single container instance in harbor
 type HelmitContainer struct {
@@ -41,6 +43,27 @@ type ShipmentStatus struct {
 		} `json:"containers"`
 	} `json:"status"`
 	AverageRestarts float32 `json:"averageRestarts"`
+}
+
+//ShipmentEventResult represents system events for a shipment/environment
+type ShipmentEventResult struct {
+	Namespace string          `json:"namespace"`
+	Version   string          `json:"version"`
+	Events    []ShipmentEvent `json:"events"`
+}
+
+//ShipmentEvent represents a shipment event
+type ShipmentEvent struct {
+	Type    string `json:"type"`
+	Count   int    `json:"count"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+	Source  struct {
+		Component string `json:"component"`
+	} `json:"source"`
+	FirstTimestamp time.Time `json:"firstTimestamp"`
+	LastTimestamp  time.Time `json:"lastTimestamp"`
+	StartTime      string
 }
 
 // ContainerState represents a particular state of a container


### PR DESCRIPTION
```
$ harbor-compose events --help

Show container orchestration events for the shipment environments in your yaml files or specified via command line arguments

Usage:
  harbor-compose events [flags]

Examples:
harbor-compose events
harbor-compose events --type all

# show only normal events
harbor-compose events --type normal

# show only warning events
harbor-compose events --type warning

# show full event messages
hargor-compose events -m

# show events for a particular shipment environment
harbor-compose events --shipment my-shipment --environment dev
harbor-compose events -s my-shipment -e dev


Flags:
  -e, --environment string   environment name
  -h, --help                 help for events
  -m, --message              include the full message
  -s, --shipment string      shipment name
  -t, --type string          specify what level of events you would like to see (normal, warning, or all) (default "all")
```

[![asciicast](https://asciinema.org/a/WNNemIFnnEW7HtRLELQrt1yNk.png)](https://asciinema.org/a/WNNemIFnnEW7HtRLELQrt1yNk)
