### PR TITLE
fixes for https-only and iam certs

### DIFF
--- a/cmd/ecsfargate_test.go
+++ b/cmd/ecsfargate_test.go
@@ -35,3 +35,46 @@ provider "aws" {
 	assert.Contains(t, result, `profile = "my-profile"`)
 	assert.Contains(t, result, `bucket  = "tf-state-my-shipment"`)
 }
+
+func TestUpdateHTTPSForIam(t *testing.T) {
+
+	tf := `
+# adds an https listener to the load balancer
+# (delete this file if you only want http)
+
+# The port to listen on for HTTPS, always use 443
+variable "https_port" {
+	default = "443"
+}
+
+# The ARN for the SSL certificate
+variable "certificate_arn" {}
+
+resource "aws_alb_listener" "https" {
+	load_balancer_arn = "${aws_alb.main.id}"
+	port              = "${var.https_port}"
+	protocol          = "HTTPS"
+	certificate_arn   = "${var.certificate_arn}"
+
+	default_action {
+		target_group_arn = "${aws_alb_target_group.main.id}"
+		type             = "forward"
+	}
+}
+
+resource "aws_security_group_rule" "ingress_lb_https" {
+	type              = "ingress"
+	description       = "HTTPS"
+	from_port         = "${var.https_port}"
+	to_port           = "${var.https_port}"
+	protocol          = "tcp"
+	cidr_blocks       = ["0.0.0.0/0"]
+	security_group_id = "${aws_security_group.nsg_lb.id}"
+}
+	`
+
+	result := updateHTTPSForIam(tf, "foo")
+	t.Log(result)
+	assert.Contains(t, result, `name_prefix = "foo"`)
+	assert.Contains(t, result, `certificate_arn   = "${data.aws_iam_server_certificate.app.arn}"`)
+}

--- a/cmd/harborAPI.go
+++ b/cmd/harborAPI.go
@@ -730,3 +730,37 @@ func GetGroup(id string) *Group {
 
 	return &result
 }
+
+func getLoadBalancerStatus(shipment string, env string) (*LoadBalancer, error) {
+
+	uri := triggerURI("/v2/loadbalancer/status/{shipment}/{env}/{provider}",
+		param("shipment", shipment),
+		param("env", env),
+		param("provider", providerEc2))
+
+	if Verbose {
+		log.Printf("getting lb status: " + uri)
+	}
+
+	//issue request
+	res, body, err := gorequest.New().Get(uri).EndBytes()
+	if err != nil {
+		return nil, err[0]
+	}
+
+	var result LoadBalancer
+	if res.StatusCode == http.StatusOK {
+		if Verbose {
+			log.Println(string(body))
+		}
+
+		unmarshalErr := json.Unmarshal(body, &result)
+		if unmarshalErr != nil {
+			return nil, unmarshalErr
+		}
+	} else {
+		return nil, fmt.Errorf("get lb status returned: %v; %v", res.StatusCode, string(body))
+	}
+
+	return &result, nil
+}

--- a/cmd/types.go
+++ b/cmd/types.go
@@ -273,3 +273,15 @@ type Group struct {
 	Users  []string `json:"users"`
 	Admins []string `json:"admins"`
 }
+
+// LoadBalancer represents a harbor load balancer
+type LoadBalancer struct {
+	Name                  string `json:"name"`
+	Type                  string `json:"type"`
+	Public                bool   `json:"public"`
+	ARN                   string `json:"arn"`
+	DNSName               string `json:"dnsName"`
+	CanonicalHostedZoneID string `json:"canonicalHostedZoneId"`
+	VpcID                 string `json:"vpcId"`
+	State                 string `json:"state"`
+}


### PR DESCRIPTION
Fixes the following for https-only:

```
ERROR: template: tf:30:23: executing "tf" at <.HTTPPort.PublicPort>: can't evaluate field PublicPort in type *cmd.terraformPort
```

Properly handles IAM server certs by emitting the following terraform based on the harbor load balancer.
```hcl
data "aws_iam_server_certificate" "app" {
  name_prefix = "k8s-1502304042212088264"
  latest      = true
}
```
```hcl
resource "aws_alb_listener" "https" {
  load_balancer_arn = "${aws_alb.main.id}"
  port              = "${var.https_port}"
  protocol          = "HTTPS"
  certificate_arn   = "${data.aws_iam_server_certificate.app.arn}"
```