### PR TITLE
fixes http-only bug

### DIFF
--- a/cmd/ecsfargate.go
+++ b/cmd/ecsfargate.go
@@ -601,10 +601,10 @@ new_image = "{{ .NewImage }}"
 
 {{ if .HTTPSPort }}
 https_port = "{{ .HTTPSPort.PublicPort }}"
-{{ end }}
 
 {{ if eq .HTTPSPort.SslManagementType "acm" }}
 certificate_arn = "{{ .HTTPSPort.SslArn }}"
+{{ end }}
 {{ end }}
 
 # https://aws.amazon.com/fargate/pricing/


### PR DESCRIPTION
```ERROR: template: tf:57:19: executing "tf" at <.HTTPSPort.SslManage...>: can't evaluate field SslManagementType in type *cmd.terraformPort```