### PR TITLE
adds --app flag and length validation

### DIFF
--- a/cmd/ecsfargate.go
+++ b/cmd/ecsfargate.go
@@ -363,6 +363,11 @@ func translateShipmentEnvironmentToEcsTerraform(shipmentEnvironment *ShipmentEnv
 		GeneratedDate: generationTime,
 	}
 
+	//override "Shipment" with --app, if specified
+	if migrateAppName != "" {
+		result.Shipment = migrateAppName
+	}
+
 	//call groups api to get contact-email address
 	result.ContactEmail = getContactEmailFromGroup(composeShipment.Group)
 	result.AwsRole = migrateRole

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -108,8 +108,9 @@ func migrate(cmd *cobra.Command, args []string) {
 	if migrateAppName != "" {
 		app = migrateAppName
 	}
-	if len(app+env) > 32 {
-		check(fmt.Errorf("%s-%s (app-env) must be <= 32 characters", app, env))
+	appEnv := fmt.Sprintf("%s-%s", app, env) 
+	if len(appEnv) > 32 {
+		check(fmt.Errorf("%s (app-env) must be <= 32 characters", appEnv))
 	}
 
 	//instantiate a build provider if specified

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -103,6 +103,15 @@ func migrate(cmd *cobra.Command, args []string) {
 	shipment := args[0]
 	env := args[1]
 
+	//validate that the "app-env" name (used for alb name) is <= 32 characters
+	app := shipment
+	if migrateAppName != "" {
+		app = migrateAppName
+	}
+	if len(app+env) > 32 {
+		check(fmt.Errorf("%s-%s (app-env) must be <= 32 characters", app, env))
+	}
+
 	//instantiate a build provider if specified
 	var provider *BuildProvider
 	if len(migrateBuildProvider) > 0 {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -27,6 +27,7 @@ harbor-compose migrate my-shipment dev --platform ecsfargate --build-provider ci
 harbor-compose migrate my-shipment prod --platform ecsfargate	
 harbor-compose migrate my-shipment prod --platform ecsfargate --role admin
 harbor-compose migrate my-shipment prod --template-tag v0.1.0
+harbor-compose migrate my-shipment prod --app my-fargate-app
 
 # migrate to the specified account
 harbor-compose migrate my-shipment prod \
@@ -50,6 +51,7 @@ var migrateAccountName string
 var migrateVPC string
 var migratePrivateSubnets string
 var migratePublicSubnets string
+var migrateAppName string
 
 func init() {
 	migrateCmd.PersistentFlags().StringVarP(&migratePlatform, "platform", "p", "ecsfargate", "target migration platform")
@@ -63,6 +65,8 @@ func init() {
 	migrateCmd.PersistentFlags().StringVar(&migrateVPC, "vpc", "", "migrate to the specified VPC ID")
 	migrateCmd.PersistentFlags().StringVar(&migratePrivateSubnets, "private-subnets", "", "migrate using the specified private subnets (comma-delimited)")
 	migrateCmd.PersistentFlags().StringVar(&migratePublicSubnets, "public-subnets", "", "migrate using the specified public subnets (comma-delimited)")
+
+	migrateCmd.PersistentFlags().StringVarP(&migrateAppName, "app", "a", "", "use this app name instead of shipment name")
 
 	RootCmd.AddCommand(migrateCmd)
 }


### PR DESCRIPTION
```
$ harbor-compose migrate coredev-filmstruck-artemis-api uat
2018/06/11 17:59:32 ERROR: coredev-filmstruck-artemis-api-uat (app-env) must be <= 32 characters

$ harbor-compose migrate coredev-filmstruck-artemis-api uat -a filmstruck-artemis-api
downloading terraform template https://github.com/turnerlabs/terraform-ecs-fargate/archive/v0.1.0.zip
...
```